### PR TITLE
flex-shrink: 0 적용하여 넓이가 안드 5.0.1 에서 자동으로 줄어드는 것 방지

### DIFF
--- a/src/components/BookSections/RankingBook/RankingBookList.tsx
+++ b/src/components/BookSections/RankingBook/RankingBookList.tsx
@@ -78,7 +78,7 @@ const listCSS = css`
 `;
 
 const itemCSS = css`
-  flex-shrink: 0;
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   box-sizing: content-box;
@@ -200,7 +200,7 @@ const ItemList: React.FC<any> = props => {
           <li css={type === 'big' ? bigItemCSS : smallItemCSS} key={index}>
             <div
               css={css`
-                flex-shrink:0;
+                flex: 0 0 auto;
                 margin-right: ${props.type === 'big' ? '18px' : '24px'};
                 height: 100%;
                 display: flex;

--- a/src/components/BookSections/RankingBook/RankingBookList.tsx
+++ b/src/components/BookSections/RankingBook/RankingBookList.tsx
@@ -78,6 +78,7 @@ const listCSS = css`
 `;
 
 const itemCSS = css`
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   box-sizing: content-box;
@@ -199,6 +200,7 @@ const ItemList: React.FC<any> = props => {
           <li css={type === 'big' ? bigItemCSS : smallItemCSS} key={index}>
             <div
               css={css`
+                flex-shrink:0;
                 margin-right: ${props.type === 'big' ? '18px' : '24px'};
                 height: 100%;
                 display: flex;

--- a/src/components/BookSections/RankingBook/RankingBookList.tsx
+++ b/src/components/BookSections/RankingBook/RankingBookList.tsx
@@ -78,7 +78,7 @@ const listCSS = css`
 `;
 
 const itemCSS = css`
-  flex: 0 0 auto;
+  flex: none;
   display: flex;
   align-items: center;
   box-sizing: content-box;
@@ -200,7 +200,7 @@ const ItemList: React.FC<any> = props => {
           <li css={type === 'big' ? bigItemCSS : smallItemCSS} key={index}>
             <div
               css={css`
-                flex: 0 0 auto;
+                flex: none;
                 margin-right: ${props.type === 'big' ? '18px' : '24px'};
                 height: 100%;
                 display: flex;

--- a/src/components/BookSections/SelectionBook/SelectionBook.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBook.tsx
@@ -129,7 +129,7 @@ export const SelectionBookItem: React.FC<SelectionBookItemProps> = React.memo(pr
     <>
       <a
         css={css`
-          display: inline-block;
+          display: block;
         `}
         onClick={sendClickEvent.bind(null, tracker, book, slug, order)}
         href={new URL(`/books/${book.b_id}`, publicRuntimeConfig.STORE_HOST).toString()}>

--- a/src/components/BookSections/SelectionBook/SelectionBookList.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookList.tsx
@@ -27,7 +27,7 @@ export const listCSS = css`
 
 export const itemCSS = css`
   display: flex;
-  flex: 0 0 auto;
+  flex: none;
   flex-direction: column;
   :first-of-type {
     padding-left: 20px;

--- a/src/components/BookSections/SelectionBook/SelectionBookList.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookList.tsx
@@ -27,6 +27,7 @@ export const listCSS = css`
 
 export const itemCSS = css`
   display: flex;
+  flex-shrink: 0;
   flex-direction: column;
   :first-of-type {
     padding-left: 20px;

--- a/src/components/BookSections/SelectionBook/SelectionBookList.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookList.tsx
@@ -27,7 +27,7 @@ export const listCSS = css`
 
 export const itemCSS = css`
   display: flex;
-  flex-shrink: 0;
+  flex: 0 0 auto;
   flex-direction: column;
   :first-of-type {
     padding-left: 20px;

--- a/src/components/BookThumbnail/ThumbnailRenderer.tsx
+++ b/src/components/BookThumbnail/ThumbnailRenderer.tsx
@@ -75,7 +75,6 @@ const thumbnailWrapperCSS = css`
   position: relative;
   line-height: 0;
   max-height: inherit;
-  
   &::after {
     display: block;
     box-sizing: border-box;

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -48,6 +48,14 @@ const Navigation = styled.nav`
 const LogoWrapper = styled.ul`
   min-height: 30px;
   margin-right: -2.5px;
+  flex: 0 0 auto;
+  ${orBelow(
+    BreakPoint.LG,
+    css`
+      height: 30px;
+      margin-right: 0;
+    `,
+  )};
   order: 1;
   margin-bottom: 0;
   display: inline-flex;
@@ -129,7 +137,7 @@ const ridiSelectLogo = (theme: RIDITheme) => css`
 const ButtonWrapper = styled.ul`
   margin-left: auto;
   display: flex;
-  top: 9px;
+  flex: 0 0 auto;
   order: 3;
   ${orBelow(
     BreakPoint.LG,
@@ -160,7 +168,7 @@ const logoAndSearchBox = css`
   ${orBelow(
     BreakPoint.LG,
     css`
-      flex-direction: column;
+      flex-wrap: wrap;
     `,
   )};
 `;

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -48,7 +48,7 @@ const Navigation = styled.nav`
 const LogoWrapper = styled.ul`
   min-height: 30px;
   margin-right: -2.5px;
-  flex: 0 0 auto;
+  flex: none;
   ${orBelow(
     BreakPoint.LG,
     css`
@@ -137,7 +137,7 @@ const ridiSelectLogo = (theme: RIDITheme) => css`
 const ButtonWrapper = styled.ul`
   margin-left: auto;
   display: flex;
-  flex: 0 0 auto;
+  flex: none;
   order: 3;
   ${orBelow(
     BreakPoint.LG,

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -129,6 +129,7 @@ const ridiSelectLogo = (theme: RIDITheme) => css`
 const ButtonWrapper = styled.ul`
   margin-left: auto;
   display: flex;
+  top: 9px;
   order: 3;
   ${orBelow(
     BreakPoint.LG,

--- a/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
+++ b/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
@@ -468,7 +468,7 @@ const HomeKeywordFinderSection: React.FC<HomeKeywordFinderSectionProps> = props 
                 key={index}
                 css={css`
                   height: 31px;
-                  flex-shrink: 0;
+                  flex: 0 0 auto;
                   :not(:last-of-type) {
                     margin-right: 6px;
                   }

--- a/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
+++ b/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
@@ -468,7 +468,7 @@ const HomeKeywordFinderSection: React.FC<HomeKeywordFinderSectionProps> = props 
                 key={index}
                 css={css`
                   height: 31px;
-                  flex: 0 0 auto;
+                  flex: none;
                   :not(:last-of-type) {
                     margin-right: 6px;
                   }

--- a/src/components/MultipleLineBooks/MultipleLineBooks.tsx
+++ b/src/components/MultipleLineBooks/MultipleLineBooks.tsx
@@ -290,7 +290,7 @@ const ItemList: React.FC<any> = props => {
       css={css`
           display: flex;
           flex-wrap: wrap;
-          flex-shrink: 0;
+          flex: 0 0 auto;
           justify-content: space-around;
           margin-bottom: -24px;
           ${orBelow(

--- a/src/components/MultipleLineBooks/MultipleLineBooks.tsx
+++ b/src/components/MultipleLineBooks/MultipleLineBooks.tsx
@@ -290,7 +290,7 @@ const ItemList: React.FC<any> = props => {
       css={css`
           display: flex;
           flex-wrap: wrap;
-          flex: 0 0 auto;
+          flex: none;
           justify-content: space-around;
           margin-bottom: -24px;
           ${orBelow(

--- a/src/components/QuickMenu/QuickMenuList.tsx
+++ b/src/components/QuickMenu/QuickMenuList.tsx
@@ -51,6 +51,7 @@ const MenuList = styled.ul`
 
 const MenuItem = styled.li`
   display: inline-block;
+  flex-shrink: 0;
   :not(:last-of-type) {
     margin-right: 9px;
   }
@@ -98,6 +99,7 @@ const Menu: React.FC<{ menu: QuickMenu }> = React.memo(props => {
             `}>
             <QuickMenuShape
               css={css`
+                flex-shrink: 0;
                 height: 44px;
                 width: 44px;
                 top: 0;

--- a/src/components/QuickMenu/QuickMenuList.tsx
+++ b/src/components/QuickMenu/QuickMenuList.tsx
@@ -51,7 +51,7 @@ const MenuList = styled.ul`
 
 const MenuItem = styled.li`
   display: inline-block;
-  flex: 0 0 auto;
+  flex: none;
   :not(:last-of-type) {
     margin-right: 9px;
   }
@@ -99,7 +99,7 @@ const Menu: React.FC<{ menu: QuickMenu }> = React.memo(props => {
             `}>
             <QuickMenuShape
               css={css`
-                flex: 0 0 auto;
+                flex: none;
                 height: 44px;
                 width: 44px;
                 top: 0;

--- a/src/components/QuickMenu/QuickMenuList.tsx
+++ b/src/components/QuickMenu/QuickMenuList.tsx
@@ -51,7 +51,7 @@ const MenuList = styled.ul`
 
 const MenuItem = styled.li`
   display: inline-block;
-  flex-shrink: 0;
+  flex: 0 0 auto;
   :not(:last-of-type) {
     margin-right: 9px;
   }
@@ -99,7 +99,7 @@ const Menu: React.FC<{ menu: QuickMenu }> = React.memo(props => {
             `}>
             <QuickMenuShape
               css={css`
-                flex-shrink: 0;
+                flex: 0 0 auto;
                 height: 44px;
                 width: 44px;
                 top: 0;

--- a/src/components/Search/InstantSearch.tsx
+++ b/src/components/Search/InstantSearch.tsx
@@ -591,6 +591,7 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
             isFocused ? focused(theme) : initial(),
             css`
               outline: none;
+              ${orBelow(BreakPoint.LG, css`width: 100%;`)}
             `,
           ]}>
           {isFocused && (


### PR DESCRIPTION
스타일이 구겨진 걸 폈습니다.


`before`
https://app.asana.com/0/1159983010965178/1160255740232849


`after`

![image](https://user-images.githubusercontent.com/45959991/74150861-2a5b2d80-4c4e-11ea-8243-623062658de5.png)
![image](https://user-images.githubusercontent.com/45959991/74150877-347d2c00-4c4e-11ea-9932-35ffd8082c16.png)


추가적으로 우상단 로그인 버튼 그룹이 올바른 위치가 아닌 부분도 수정했습니다.
