### PR TITLE
manifest 경로 cdn 으로 이동

### DIFF
--- a/src/pages/Meta.tsx
+++ b/src/pages/Meta.tsx
@@ -32,7 +32,7 @@ export default () => (
       name="description"
       content="웹툰/웹소설, 전자책, 만화까지 취향에 딱 맞는 콘텐츠를 제안합니다."
     />
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" href={`${publicRuntimeConfig.STATIC_CDN_URL}/_next/manifest.webmanifest`} />
     <link
       href="https://fonts.googleapis.com/css?family=Nanum+Gothic&display=swap&subset=korean"
       rel="stylesheet"


### PR DESCRIPTION
static 경로에 manifest.webmanifest 가 이미 맞는 경로명으로 올라가 있었습니다. 
그 경로를 사용하도록 변경합니다.

*관련 태스크*
https://app.asana.com/0/1159983010965178/1161096864403145