### PR TITLE
Fix: next build command in build-dev ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - checkout
       - install
       - run:
-          command: yarn build src
+          command: yarn next build src
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
개발 서버에서 `ENVIRONMENT` 환경 변수를 인식하지 못하는 문제 해결