### PR TITLE
CSP 서드파티 벤더 따로 분리 및 오타 수정

### DIFF
--- a/server/csp.js
+++ b/server/csp.js
@@ -1,5 +1,29 @@
 const helmet = require('helmet');
 const uuid_v4 = require('uuid');
+
+const thirdPartyVendors = [
+  'www.google-analytics.com',
+  'www.googletagmanager.com',
+  'connect.facebook.net',
+  'https://fonts.googleapis.com',
+  'www.google.com',
+  'www.google.co.kr',
+  'sentry.io',
+  'stats.g.doubleclick.net',
+  'www.facebook.com',
+  'stats.g.doubleclick.net',
+  'staticxx.facebook.com',
+  'connect.facebook.net'
+];
+
+const whiteList = [
+  'https://*.ridi.io',
+  'https://*.ridibooks.com',
+  'https://ridibooks.com',
+  'https://books.ridibooks.com',
+  'https://*.ridicdn.net',
+];
+
 module.exports = function csp(app) {
   app.use((req, res, next) => {
     res.locals.nonce = Buffer.from(uuid_v4()).toString('base64');
@@ -8,27 +32,18 @@ module.exports = function csp(app) {
 
   const nonce = (req, res) => `'nonce-${res.locals.nonce}'`;
 
-  const whiteList = [
-    'https://*.ridi.io',
-    'https://*.ridibooks.com',
-    'https://ridibooks.com',
-    'https://books.ridibooks.com',
-    'https://*.ridicdn.net',
-  ];
 
   const scriptSrc = [
     nonce,
     "'strict-dynamic'",
     "'self'",
-    'www.google-analytics.com',
-    'www.googletagmanager.com',
-    'connect.facebook.net',
+    ...thirdPartyVendors,
     ...whiteList,
   ];
   const styleSrc = [
     "'self'",
     "'unsafe-inline'",
-    "'https://fonts.googleapis.com'",
+    ...thirdPartyVendors,
     ...whiteList,
   ];
 
@@ -46,13 +61,9 @@ module.exports = function csp(app) {
           objectSrc: ["'none'"],
           imgSrc: [
             "'self'",
+            // Todo Use CNAME
             'https://*.amazonaws.com',
-            'www.facebook.com',
-            'www.google.com',
-            'www.google.co.kr',
-            'www.google-analytics.com',
-            'www.googletagmanager.com',
-            'stats.g.doubleclick.net',
+            ...thirdPartyVendors,
             ...whiteList,
           ],
           frameSrc: ['staticxx.facebook.com', 'connect.facebook.net'],
@@ -60,14 +71,9 @@ module.exports = function csp(app) {
           scriptSrc,
           connectSrc: [
             "'self'",
-            'sentry.io',
-            'www.google-analytics.com',
-            'stats.g.doubleclick.net',
-            'www.facebook.com',
-            'www.google-analytics.com',
-            'www.googletagmanager.com',
-            'connect.facebook.net',
+            // Todo Use CNAME
             'https://*.amazonaws.com',
+            ...thirdPartyVendors,
             ...whiteList,
           ],
           reportUri: `https://sentry.io/api/1402572/security/?sentry_key=a0a997382844435fa6c89803ef6ce8e5&sentry_environment=${process.env.NODE_ENV};`,


### PR DESCRIPTION
여전히 센트리에 잡혀서 확인해보니 따옴표 미스가 있었습니다. 

`"'https://fonts.googleapis.com'"` ->   "https://fonts.googleapis.com"


참고로 CSP `style-src-elem` 지시자가 없으면 `style-src` 를 보고 둘 다 없으면 `default-src` 봅니다. 
helmet 에서는  style-src-elem 은 지원하지 않네요 

또한 서드파티 벤더 목록을 공통 변수로 이동했습니다.