### PR TITLE
Hotfix/Edge 에서는 URLSearchParam 객체를 생성자로 포함이 불가능 한 부분 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "slick-carousel": "^1.8.1",
     "ts-get": "^1.0.5",
     "ua-parser-js": "^0.7.20",
+    "url-search-params-polyfill": "^8.0.0",
     "use-debounce": "^3.1.0",
     "uuid": "^3.3.3",
     "workbox-webpack-plugin": "^4.3.1",

--- a/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
+++ b/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
@@ -6,6 +6,7 @@ import { displayNoneForTouchDevice, scrollBarHidden } from 'src/styles';
 import Arrow, { arrowTransition } from 'src/components/Carousel/Arrow';
 import { useScrollSlider } from 'src/hooks/useScrollSlider';
 import { DeviceTypeContext } from 'src/components/Context/DeviceType';
+import 'url-search-params-polyfill';
 
 interface Keyword {
   genre: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14412,6 +14412,11 @@ url-polyfill@1.1.7:
   resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.7.tgz#402ee84360eb549bbeb585f4c7971e79a31de9e3"
   integrity sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA==
 
+url-search-params-polyfill@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.0.0.tgz#17415ca6815ff0661e07737b84bcc28e708a7875"
+  integrity sha512-X4BTaEq1UMz9bTbMKQ6r+CippkKBsFWHiP9wycQc7aHH2Ml/Iieuo44+GJDb77pfP71bONYA/nUd4iokYAxVRQ==
+
 url-to-options@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"


### PR DESCRIPTION
관련 태스크 
https://app.asana.com/0/1162174540914970/1162179916806361  

Edge 4x 또는 그 이하에서는 `URLSearchParam` 을 생성할 때 `URLSearchParam` 의 인스턴스를 넣는 것이 불가능합니다. 
폴리필을 추가했고 테스트 완료 하였습니다.   


https://github.com/ridi/books-frontend/blob/d5e41244a500d11579b39d60d2c308361a7db924/src/components/KeywordFinder/HomeKeywordFinderSection.tsx#L463


https://github.com/ridi/books-frontend/blob/d5e41244a500d11579b39d60d2c308361a7db924/src/components/KeywordFinder/HomeKeywordFinderSection.tsx#L496
