### PR TITLE
axios-logger 관련 모듈을 Next.js 에서 트랜스파일 못하는 부분을 수정합니다. (for IE11)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -122,6 +122,9 @@ module.exports = withBundleAnalyzer(
           );
           const sentryConfig = addSentryConfig(publicRuntimeConfig, buildId);
           config.plugins.push(new webpack.DefinePlugin(getDefinitionsFromConfig(sentryConfig)));
+          config.plugins.push(new webpack.DefinePlugin({
+            'process.env.IS_SERVER': JSON.stringify(isServer),
+          }));
 
           config.node = {
             net: 'empty',

--- a/next.config.js
+++ b/next.config.js
@@ -22,7 +22,7 @@ module.exports = withBundleAnalyzer(
   nextSourceMaps(
     withCSS(
       withTM({
-        transpileModules: ['p-retry', 'ansi-styles', 'axios-logger', 'chalk'], // for IE11
+        transpileModules: ['p-retry'], // for IE11
         distDir: '../build',
         assetPrefix: STATIC_CDN_URL || 'https://books.ridicdn.net',
         useFileSystemPublicRoutes: false,

--- a/next.config.js
+++ b/next.config.js
@@ -22,7 +22,7 @@ module.exports = withBundleAnalyzer(
   nextSourceMaps(
     withCSS(
       withTM({
-        transpileModules: ['p-retry'], // for IE11
+        transpileModules: ['p-retry', 'ansi-styles', 'axios-logger', 'chalk'], // for IE11
         distDir: '../build',
         assetPrefix: STATIC_CDN_URL || 'https://books.ridicdn.net',
         useFileSystemPublicRoutes: false,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@zeit/next-bundle-analyzer": "^0.1.2",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-source-maps": "^0.0.4-canary.1",
-    "axios": "0.18.1",
+    "axios": "^0.19.2",
     "axios-logger": "^2.3.1",
     "compression": "^1.7.4",
     "connected-next-router": "^1.0.1",
@@ -126,5 +126,8 @@
     "Android >= 4.2",
     "iOS >= 10",
     "ie >= 11"
-  ]
+  ],
+  "browser": {
+    "axios-logger": false
+  }
 }

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -37,11 +37,12 @@ export function wrapCatchCancel<F extends Function>(f: F): F {
 const createAxiosInstances = (): AxiosInstance => {
   const instance = axios.create({ timeout: TIME_OUT });
   instance.interceptors.response.use((onFulfilled) => onFulfilled, tokenInterceptor);
-  if (process.env.SERVERLESS) {
-    import('axios-logger').then((logger) => {
-      instance.interceptors.request.use(logger.requestLogger, logger.errorLogger);
-      instance.interceptors.response.use(logger.responseLogger, logger.errorLogger);
-    });
+  if (process.env.IS_SERVER) {
+    // 여기서는 Node.js가 로드한다는 걸 알고 있으므로 require를 직접 씁니다.
+    // eslint-disable-next-line global-require
+    const AxiosLogger = require('axios-logger');
+    instance.interceptors.request.use(AxiosLogger.requestLogger, AxiosLogger.errorLogger);
+    instance.interceptors.response.use(AxiosLogger.responseLogger, AxiosLogger.errorLogger);
   }
   return instance;
 };

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -37,8 +37,7 @@ export function wrapCatchCancel<F extends Function>(f: F): F {
 const createAxiosInstances = (): AxiosInstance => {
   const instance = axios.create({ timeout: TIME_OUT });
   instance.interceptors.response.use((onFulfilled) => onFulfilled, tokenInterceptor);
-  // HACK IE11 동작은 확인
-  if (typeof window === 'undefined' && publicRuntimeConfig.ENVIRONMENT !== 'local') {
+  if (process.env.SERVERLESS) {
     import('axios-logger').then((logger) => {
       instance.interceptors.request.use(logger.requestLogger, logger.errorLogger);
       instance.interceptors.response.use(logger.responseLogger, logger.errorLogger);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4174,13 +4174,12 @@ axios-logger@^2.3.1:
     chalk "^2.4.1"
     dateformat "^3.0.3"
 
-axios@0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
-  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
 
 axobject-query@^2.0.2:
   version "2.0.2"
@@ -8531,7 +8530,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.2, is-buffer@~2.0.3:
+is-buffer@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==


### PR DESCRIPTION
`SERVERLESS` 환경 변수를 바라보고 dynamic import 를 합니다.
package.json 에 browser 에 axios-logger 를 `false` 처리 합니다.