### PR TITLE
스케줄 된 Google Lighthouse audit 추가 

### DIFF
--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -2,7 +2,7 @@ name: Google Lighthouse
 
 on:
   schedule:
-    - cron: '* */12 * * *'
+    - cron: '0 */12 * * *'
 
 jobs:
   lighthouse:

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -1,0 +1,21 @@
+name: Google Lighthouse 
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Audit ridibooks.com using Lighthouse
+      uses: treosh/lighthouse-ci-action@v2
+      with:
+        urls: |
+          https://ridibooks.com
+    - name: Save Results
+      uses: actions/upload-artifact@v1
+      with:
+        name: lighthouse-results
+        path: '.lighthouseci' # This will save the Lighthouse results as .json files

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -2,7 +2,7 @@ name: Google Lighthouse
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '* */12 * * *'
 
 jobs:
   lighthouse:


### PR DESCRIPTION
- Google Lighthouse Audit 을 Github Actions 스케줄 잡으로 돌려보는 테스트입니다.
- ~~일단 10분 마다~~ **12 시간마다** 돌려보는데 Merge 후 리포팅이 확인 후 스케줄 주기는 변경 예정입니다. 