### PR TITLE
lighthouse github actions plugin 사용하지 않고 직접 lighthouse-ci 호출사용으로 변경

### DIFF
--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -13,6 +13,9 @@ jobs:
     name: Lighthouse CI
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Setup NodeJS
         uses: actions/setup-node@v1
         with:
@@ -21,7 +24,10 @@ jobs:
       - name: Run Lighhouse CI
         run: |
           npm install -g @lhci/cli
-          lhci collect --numberOfRuns=5 --url=https://ridibooks.com
+          lhci collect --numberOfRuns=5 --url=https://ridibooks.com --url=https://ridibooks.com/comics
+          lhci upload --config=./lighthouserc.json
+          lhci upload --target=temporary-public-storage
+
 
       - name: Save Results
         uses: actions/upload-artifact@v1

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - chore/add-lighthouserc.json
       - master
+      - release/*
   schedule:
     - cron: '*/5 * * * *'
 
@@ -30,7 +31,14 @@ jobs:
 #          lhci upload --target=temporary-public-storage
 
 
-      - name: Save Results
+      - name: Upload LHCI Server
+        env:
+          LHCI_BASE_URL: ${{ secrets.LHCI_BASE_URL }}
+          LHCI_SERVER_PROJECT_TOKEN: ${{ secrets.LHCI_SERVER_PROJECT_TOKEN }}
+        run: |
+          lhci upload --serverBaseUrl=$LHCI_BASE_URL --target lhci --token $LHCI_SERVER_PROJECT_TOKEN
+
+      - name: Save Aritifact
         uses: actions/upload-artifact@v1
         with:
           name: lighthouse-results

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -3,11 +3,10 @@ name: Google Lighthouse
 on:
   push:
     branches:
-      - chore/add-lighthouserc.json
       - master
       - release/*
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '0 */12 * * *'
 
 jobs:
   lighthouse:

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install LHCI Package & Collect LH
         run: |
-          yarn global add @lhci/cli
+          npm install -G @lhci/cli
           lhci collect --numberOfRuns=5 --url=https://ridibooks.com
 
       - name: Save Results

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   lighthouse:
+    name: Lighthouse CI
     runs-on: ubuntu-latest
     steps:
       - name: Setup NodeJS
@@ -17,9 +18,9 @@ jobs:
         with:
           node-version: 10.x
 
-      - name: Install LHCI Package & Collect LH
+      - name: Run Lighhouse CI
         run: |
-          npm install -G @lhci/cli
+          npm install -g @lhci/cli
           lhci collect --numberOfRuns=5 --url=https://ridibooks.com
 
       - name: Save Results

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -1,12 +1,8 @@
 name: Google Lighthouse
 
 on:
-  push:
-    branches:
-      - master
-      - release/*
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '0/5 * * * *'
 
 jobs:
   lighthouse:

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -1,6 +1,10 @@
 name: Google Lighthouse
 
 on:
+  push:
+    branches:
+      - chore/add-lighthouserc.json
+      - master
   schedule:
     - cron: '*/5 * * * *'
 
@@ -9,16 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup NodeJS
-          uses: actions/setup-node@v1
-          with:
-            node-version: 10.x
-      - name: Install LHCI Package
-        run: |
-          yarn global add @lhci/cli@0.3.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
 
-      - name: Collect
+      - name: Install LHCI Package & Collect LH
         run: |
+          yarn global add @lhci/cli
           lhci collect --numberOfRuns=5 --url=https://ridibooks.com
+
       - name: Save Results
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -1,21 +1,26 @@
-name: Google Lighthouse 
+name: Google Lighthouse
 
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '*/5 * * * *'
 
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Audit ridibooks.com using Lighthouse
-      uses: treosh/lighthouse-ci-action@v2
-      with:
-        urls: |
-          https://ridibooks.com
-    - name: Save Results
-      uses: actions/upload-artifact@v1
-      with:
-        name: lighthouse-results
-        path: '.lighthouseci' # This will save the Lighthouse results as .json files
+      - name: Setup NodeJS
+          uses: actions/setup-node@v1
+          with:
+            node-version: 10.x
+      - name: Install LHCI Package
+        run: |
+          yarn global add @lhci/cli@0.3.x
+
+      - name: Collect
+        run: |
+          lhci collect --numberOfRuns=5 --url=https://ridibooks.com
+      - name: Save Results
+        uses: actions/upload-artifact@v1
+        with:
+          name: lighthouse-results
+          path: '.lighthouseci' # This will save the Lighthouse results as .json files

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -22,11 +22,12 @@ jobs:
           node-version: 10.x
 
       - name: Run Lighhouse CI
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
         run: |
           npm install -g @lhci/cli
-          lhci collect --numberOfRuns=5 --url=https://ridibooks.com --url=https://ridibooks.com/comics
-          lhci upload --config=./lighthouserc.json
-          lhci upload --target=temporary-public-storage
+          lhci autorun
+#          lhci upload --target=temporary-public-storage
 
 
       - name: Save Results

--- a/.github/workflows/google-lighthouse.yml
+++ b/.github/workflows/google-lighthouse.yml
@@ -2,7 +2,7 @@ name: Google Lighthouse
 
 on:
   schedule:
-    - cron: '0/5 * * * *'
+    - cron: '0 */1 * * *'
 
 jobs:
   lighthouse:

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -12,6 +12,58 @@
     "assert": {
       "preset": "lighthouse:recommended",
       "assertions": {
+        "color-contrast": [
+          "warn", {}
+        ],
+        "dom-size": [
+          "warn",{}
+        ],
+        "errors-in-console": [
+          "warn",{}
+        ],
+        "image-alt": [
+          "warn",{}
+        ],
+        "image-aspect-ratio": [
+          "warn",{}
+        ],
+        "list": [
+          "warn",{}
+        ],
+        "offline-start-url": [
+          "warn",{}
+        ],
+        "offscreen-images": [
+          "warn",{}
+        ],
+        "tap-targets": [
+          "warn",{}
+        ],
+        "total-byte-weight": [
+          "warn",{}
+        ],
+        "unminified-css": [
+          "warn",{}
+        ],
+        "unused-css-rules": [
+          "warn",{}
+        ],
+        "uses-optimized-images": [
+          "warn",{}
+        ],
+        "uses-rel-preconnect": [
+          "warn",{}
+        ],
+        "uses-responsive-images": [
+          "warn",{}
+        ],
+        "works-offline": [
+          "off",{}
+        ],
+
+        "service-worker": [
+          "warn",{}
+        ],
         "first-contentful-paint": [
           "warn",
           {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,13 +1,32 @@
 {
   "ci": {
     "collect": {
-      "numberOfRuns": 5
+      "numberOfRuns": 3,
+      "url": [
+        "https://ridibooks.com",
+        "https://ridibooks.com/fantasy",
+        "https://ridibooks.com/comics",
+        "https://ridibooks.com/romance"
+      ]
     },
     "assert": {
       "preset": "lighthouse:recommended",
       "assertions": {
-        "offscreen-images": "off",
-        "uses-webp-images": "off"
+        "first-contentful-paint": [
+          "warn",
+          {
+            "maxNumericValue": 2500,
+            "aggregationMethod": "optimistic"
+          }
+        ],
+        "interactive": [
+          "warn",
+          {
+            "maxNumericValue": 5000,
+            "aggregationMethod": "optimistic"
+          }
+        ],
+        "uses-long-cache-ttl": "off"
       }
     },
     "upload": {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,17 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 5
+    },
+    "assert": {
+      "preset": "lighthouse:recommended",
+      "assertions": {
+        "offscreen-images": "off",
+        "uses-webp-images": "off"
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
actions 사용하지 않고 직접 호출해서 기록하도록 변경합니다.
- [x] lhci 사용
- ~~[ ] cron 확인~~
- [x] lhci 저장 서버 EB 만들기
- [x] lhci 업로드



일단 에러가 많아서 `대부분의 audit 에 warn` 을 걸어뒀습니다. 
참고 또는 모니터링 용 점수라고 생각하시면 될 거 같아요.

결과 확인은 여기에 ec2 작은 거 하나 띄워서 볼 수 있습니다.
`http://ridi-lhci.ap-northeast-2.elasticbeanstalk.com/`
Repo. 
https://github.com/ridi/frontend-lhci-server
