### PR TITLE
useViewportIntersection 추가

### DIFF
--- a/src/hooks/useViewportIntersection.tsx
+++ b/src/hooks/useViewportIntersection.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+type Callback = (visible: boolean) => void;
+
+interface Context {
+  observer?: false | IntersectionObserver;
+  getRegisterRef<T extends Element>(callback: Callback): React.Ref<T>;
+}
+
+const ViewportIntersectionContext = React.createContext<Context | null>(null);
+
+type Props = Omit<IntersectionObserverInit, 'root'> & { children?: React.ReactNode };
+
+export function ViewportIntersectionProvider(props: Props) {
+  const { children, ...options } = props;
+  const targets = React.useRef<Map<Element, Callback>>(new Map());
+  let observerRef: React.MutableRefObject<Context>;
+  const getRegisterRef = React.useCallback(
+    (callback: Callback) => {
+      let previousNode = null;
+      const ref: <T extends Element>(node: T | null) => void = (node) => {
+        const { observer } = observerRef.current;
+        if (node == null && previousNode != null) {
+          targets.current.delete(previousNode);
+          if (observer) {
+            observer.unobserve(previousNode);
+          }
+        } else {
+          targets.current.set(node, callback);
+          if (observer === false) {
+            callback(true);
+          } else {
+            observer?.observe(node);
+          }
+        }
+        previousNode = node;
+      };
+      return ref;
+    },
+    [],
+  );
+  observerRef = React.useRef<Context>({ getRegisterRef });
+
+  React.useEffect(() => {
+    if (typeof window.IntersectionObserver !== 'function') {
+      observerRef.current.observer = false;
+      targets.current.forEach((callback) => callback(true));
+      return;
+    }
+    const io = new window.IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const intersecting = entry.isIntersecting || entry.intersectionRatio > 0;
+          const node = entry.target;
+          targets.current.get(node)?.(intersecting);
+        });
+      },
+      options,
+    );
+    targets.current.forEach((_, key) => {
+      io.observe(key);
+    });
+    observerRef.current.observer = io;
+    return () => {
+      io.disconnect();
+      observerRef.current.observer = undefined;
+    };
+  }, []);
+
+  return (
+    <ViewportIntersectionContext.Provider value={observerRef.current}>
+      {children}
+    </ViewportIntersectionContext.Provider>
+  );
+}
+
+/**
+ * 뷰포트 영역의 IntersectionObserver에 엘리먼트를 등록하는 ref를 반환하는
+ * 훅입니다.
+ *
+ * 상위에 ViewportIntersectionProvider가 있어야 합니다.
+ *
+ * @argument callback 엘리먼트가 뷰포트 영역에 들어오거나 나갈 때 실행될 함수
+ * @returns 추적할 엘리먼트에 붙일 ref
+ */
+export function useViewportIntersection<T extends Element>(callback: Callback): React.Ref<T> {
+  const ctx = React.useContext(ViewportIntersectionContext);
+  const ref = React.useMemo(() => {
+    if (ctx == null) {
+      return null;
+    }
+    return ctx.getRegisterRef<T>(callback);
+  }, [ctx, callback]);
+  return ref;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,6 +20,7 @@ import { PartialSeparator } from 'src/components/Misc';
 import { cache } from 'emotion';
 import createCache from '@emotion/cache';
 
+import { ViewportIntersectionProvider } from 'src/hooks/useViewportIntersection';
 import Meta from 'src/pages/Meta';
 import sentry from 'src/utils/sentry';
 
@@ -149,15 +150,17 @@ class StoreApp extends App<StoreAppProps, StoreAppState> {
             <ConnectedRouter>
               {/* Todo Apply Layout */}
               <ThemeProvider theme={defaultTheme}>
-                <GNB
-                  searchKeyword={query.search || query.q}
-                  isPartials={false}
-                  isLoginForPartials={query.is_login}
-                />
-                <Contents>
-                  <Component {...pageProps} />
-                </Contents>
-                <Footer />
+                <ViewportIntersectionProvider rootMargin="100px">
+                  <GNB
+                    searchKeyword={query.search || query.q}
+                    isPartials={false}
+                    isLoginForPartials={query.is_login}
+                  />
+                  <Contents>
+                    <Component {...pageProps} />
+                  </Contents>
+                  <Footer />
+                </ViewportIntersectionProvider>
               </ThemeProvider>
             </ConnectedRouter>
           </Provider>

--- a/src/tests/hooks/useViewportIntersection.spec.tsx
+++ b/src/tests/hooks/useViewportIntersection.spec.tsx
@@ -1,0 +1,201 @@
+import { act, render, cleanup, RenderResult } from '@testing-library/react';
+import React from 'react';
+
+import { ViewportIntersectionProvider, useViewportIntersection } from 'src/hooks/useViewportIntersection';
+
+class MockIO {
+  elements: Set<Element> = new Set();
+  static visibleElements: Set<Element> = new Set();
+  static activeIOs: Set<MockIO> = new Set();
+
+  constructor(
+    public callback: IntersectionObserverCallback,
+    public options?: IntersectionObserverInit,
+  ) {
+    MockIO.activeIOs.add(this);
+  }
+
+  observe(e: Element) {
+    this.elements.add(e);
+    this.changeVisibility(e, MockIO.visibleElements.has(e));
+  }
+
+  unobserve(e: Element) {
+    this.elements.delete(e);
+  }
+
+  private changeVisibility(e: Element, visible: boolean) {
+    const entry = {
+      target: e,
+      intersectionRatio: visible ? 1 : 0,
+      isIntersecting: visible,
+    };
+    this.callback([entry as any], this as unknown as IntersectionObserver);
+  }
+
+  static reveal(e: Element) {
+    if (MockIO.visibleElements.has(e)) {
+      return;
+    }
+    MockIO.visibleElements.add(e);
+    for (const io of MockIO.activeIOs.values()) {
+      if (io.elements.has(e)) {
+        io.changeVisibility(e, true);
+      }
+    }
+  }
+
+  static hide(e: Element) {
+    if (!MockIO.visibleElements.has(e)) {
+      return;
+    }
+    MockIO.visibleElements.delete(e);
+    for (const io of MockIO.activeIOs.values()) {
+      if (io.elements.has(e)) {
+        io.changeVisibility(e, false);
+      }
+    }
+  }
+
+  disconnect() {
+    this.elements.clear();
+    MockIO.activeIOs.delete(this);
+  }
+}
+
+describe('useViewportIntersection', () => {
+  function TestComponent(props: { callback: (visible: boolean) => void }) {
+    const ref = useViewportIntersection(props.callback);
+    return (
+      <div ref={ref} />
+    );
+  }
+
+  let originalIO: typeof MockIO;
+
+  beforeAll(() => {
+    originalIO = window.IntersectionObserver as unknown as typeof MockIO;
+    window.IntersectionObserver = MockIO as unknown as typeof IntersectionObserver;
+  });
+
+  afterAll(() => {
+    window.IntersectionObserver = originalIO as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    act(() => {
+      cleanup();
+    });
+  });
+
+  test('should do nothing if ViewportIntersectionProvider is unavailable', () => {
+    const callback = jest.fn();
+    act(() => {
+      render(
+        <TestComponent callback={callback} />
+      );
+    });
+    expect(callback).not.toBeCalled();
+  });
+
+  test('should be able to run callbacks', () => {
+    const callback = jest.fn();
+    let component: RenderResult;
+    act(() => {
+      component = render(
+        <ViewportIntersectionProvider>
+          <TestComponent callback={callback} />
+        </ViewportIntersectionProvider>
+      );
+    });
+    const divElement = component.container.querySelector('div');
+    expect(callback).toBeCalledWith(false);
+
+    callback.mockClear();
+    act(() => {
+      MockIO.reveal(divElement);
+    });
+    expect(callback).toBeCalledWith(true);
+
+    callback.mockClear();
+    act(() => {
+      MockIO.hide(divElement);
+    });
+    expect(callback).toBeCalledWith(false);
+  });
+
+  test('should behave properly when ref is changed', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    let component: RenderResult;
+    act(() => {
+      component = render(
+        <ViewportIntersectionProvider>
+          <TestComponent callback={callback1} />
+        </ViewportIntersectionProvider>
+      );
+    });
+    const divElement = component.container.querySelector('div');
+    const io: MockIO = MockIO.activeIOs.values().next().value;
+    const unobserveSpy = jest.spyOn(io, 'unobserve');
+    act(() => {
+      MockIO.reveal(divElement);
+    });
+    act(() => {
+      component.rerender(
+        <ViewportIntersectionProvider>
+          <TestComponent callback={callback2} />
+        </ViewportIntersectionProvider>
+      );
+    });
+    expect(unobserveSpy).toBeCalledWith(divElement);
+    expect(io.elements.has(divElement)).toBeTruthy();
+    expect(callback2).toBeCalledWith(true);
+  });
+
+  describe('IO unavailable', () => {
+    let originalIO: any;
+
+    beforeAll(() => {
+      originalIO = window.IntersectionObserver;
+      window.IntersectionObserver = undefined;
+    });
+
+    afterAll(() => {
+      window.IntersectionObserver = originalIO;
+    });
+
+    test('should be always visible when IO is unavailable', () => {
+      const callback = jest.fn();
+      act(() => {
+        render(
+          <ViewportIntersectionProvider>
+            <TestComponent callback={callback} />
+          </ViewportIntersectionProvider>
+        );
+      });
+      expect(callback).toBeCalledWith(true);
+    });
+
+    test('should behave properly when ref is changed', () => {
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+      let component: RenderResult;
+      act(() => {
+        component = render(
+          <ViewportIntersectionProvider>
+            <TestComponent callback={callback1} />
+          </ViewportIntersectionProvider>
+        );
+      });
+      act(() => {
+        component.rerender(
+          <ViewportIntersectionProvider>
+            <TestComponent callback={callback2} />
+          </ViewportIntersectionProvider>
+        );
+      });
+      expect(callback2).toBeCalledWith(true);
+    });
+  });
+});


### PR DESCRIPTION
캐러셀 PR에서 꺼내왔습니다. 하나의 `IntersectionObserver`로 모든 엘리먼트를 트래킹할 수 있도록 합니다.

IO가 트래킹할 엘리먼트를 찾는 방식이 아닌, 트래킹이 필요한 엘리먼트가 IO에 등록하는 방식입니다. 예시는 캐러셀 PR에 있어요
