### PR TITLE
useViewportIntersection ref에 null이 연속 두번 들어오는 경우 처리

### DIFF
--- a/src/hooks/useViewportIntersection.tsx
+++ b/src/hooks/useViewportIntersection.tsx
@@ -19,13 +19,18 @@ export function ViewportIntersectionProvider(props: Props) {
     (callback: Callback) => {
       let previousNode = null;
       const ref: <T extends Element>(node: T | null) => void = (node) => {
+        if (node === previousNode) {
+          return;
+        }
+
         const { observer } = observerRef.current;
-        if (node == null && previousNode != null) {
+        if (previousNode != null) {
           targets.current.delete(previousNode);
           if (observer) {
             observer.unobserve(previousNode);
           }
-        } else {
+        }
+        if (node != null) {
           targets.current.set(node, callback);
           if (observer === false) {
             callback(true);

--- a/src/tests/hooks/useViewportIntersection.spec.tsx
+++ b/src/tests/hooks/useViewportIntersection.spec.tsx
@@ -16,11 +16,17 @@ class MockIO {
   }
 
   observe(e: Element) {
+    if (!(e instanceof Element)) {
+      throw new TypeError('not an element');
+    }
     this.elements.add(e);
     this.changeVisibility(e, MockIO.visibleElements.has(e));
   }
 
   unobserve(e: Element) {
+    if (!(e instanceof Element)) {
+      throw new TypeError('not an element');
+    }
     this.elements.delete(e);
   }
 


### PR DESCRIPTION
지금 원래코드 다시보니 말도 안되는 분기네요
