### PR TITLE
Refactor/인스턴트 검색 결과 및 히스토리 style 정리

### DIFF
--- a/src/components/Search/InstantSearchHistory.tsx
+++ b/src/components/Search/InstantSearchHistory.tsx
@@ -2,12 +2,13 @@ import React, { useEffect } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import * as labels from 'src/labels/instantSearch.json';
+import * as colors from '@ridi/colors';
 import { RIDITheme } from 'src/styles';
 import Exclamation from 'src/svgs/Exclamation_1.svg';
 import Close from 'src/svgs/Close_2.svg';
 import { BreakPoint, orBelow } from 'src/utils/mediaQuery';
 
-const turnOffSearchHistory = (theme: RIDITheme) => css`
+const TurnOffSearchHistory = styled.div`
   text-align: center;
   width: 100%;
   height: 160px;
@@ -18,14 +19,18 @@ const turnOffSearchHistory = (theme: RIDITheme) => css`
   vertical-align: middle;
   box-sizing: content-box;
   font-size: 14px;
-  color: ${theme.label3};
+  color: ${colors.slateGray80}; 
 `;
 
-const recentHistoryLabel = (theme: RIDITheme) => css`
+const RecentHistoryLabel = styled.p`
   padding: 13px 0 13px 16px;
   font-size: 14px;
   font-weight: normal;
-  color: ${theme.label2};
+  color: ${colors.slateGray50};
+`;
+
+const RemoveHistoryButton = styled.button`
+  margin-left: 16px;
 `;
 
 const closeIcon = (theme: RIDITheme) => css`
@@ -41,7 +46,7 @@ const exclamation = (theme: RIDITheme) => css`
   height: 14px;
 `;
 
-const historyListCSS = () => css`
+const HistoryList = styled.ul`
   li {
     box-sizing: border-box;
   }
@@ -83,21 +88,25 @@ const SearchHistoryItem = styled.li`
   outline: none;
 `;
 
-const historyOptionPanelCSS = (theme) => css`
+const HistoryOptionPanel = styled.div`
   padding: 13px 16px;
   cursor: pointer;
   display: flex;
   justify-content: space-between;
-  background-color: ${theme.divider};
-  color: ${theme.input.placeholder};
+  background-color: ${colors.slateGray5};
+  color: ${colors.slateGray50};
   font-size: 14px;
   line-height: 1;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
   button {
-    color: ${theme.label3};
+    color: ${colors.slateGray80};
     opacity: 0.7;
   }
+`;
+
+const HistoryOptionButton = styled.button`
+  font-size: 14px;
 `;
 
 interface InstantSearchHistoryProps {
@@ -138,8 +147,8 @@ const InstantSearchHistory: React.FC<InstantSearchHistoryProps> = (props) => {
   }, [focusedPosition]);
   return (
     <>
-      <p css={recentHistoryLabel}>{labels.recentKeywords}</p>
-      <ul css={historyListCSS} ref={wrapperRef}>
+      <RecentHistoryLabel>{labels.recentKeywords}</RecentHistoryLabel>
+      <HistoryList ref={wrapperRef}>
         {enableSearchHistoryRecord ? (
           <>
             {searchHistory.slice(0, 5).map((history: string, index: number) => (
@@ -154,22 +163,19 @@ const InstantSearchHistory: React.FC<InstantSearchHistoryProps> = (props) => {
                 <a href="#history">
                   <span>{history}</span>
                 </a>
-                <button
-                  css={css`
-                    margin-left: 16px;
-                  `}
+                <RemoveHistoryButton
                   data-value={history}
-                  type="submit"
+                  type="button"
                   onClick={handleRemoveHistory}
                 >
                   <Close css={closeIcon} />
                   <span className="a11y">{labels.removeHistory}</span>
-                </button>
+                </RemoveHistoryButton>
               </SearchHistoryItem>
             ))}
           </>
         ) : (
-          <div css={turnOffSearchHistory}>
+          <TurnOffSearchHistory>
             <Exclamation css={exclamation} />
             <span
               css={css`
@@ -178,31 +184,25 @@ const InstantSearchHistory: React.FC<InstantSearchHistoryProps> = (props) => {
             >
               {labels.turnOffStatus}
             </span>
-          </div>
+          </TurnOffSearchHistory>
         )}
-      </ul>
-      <div css={historyOptionPanelCSS}>
-        <button
-          css={css`
-            font-size: 14px;
-          `}
-          type="submit"
+      </HistoryList>
+      <HistoryOptionPanel>
+        <HistoryOptionButton
+          type="button"
           onClick={handleToggleSearchHistoryRecord}
         >
           {enableSearchHistoryRecord
             ? labels.turnOffSearchHistory
             : labels.turnOnSearchHistory}
-        </button>
-        <button
-          css={css`
-            font-size: 14px;
-          `}
-          type="submit"
+        </HistoryOptionButton>
+        <HistoryOptionButton
+          type="button"
           onClick={handleClearHistory}
         >
           {enableSearchHistoryRecord && labels.clearSearchHistory}
-        </button>
-      </div>
+        </HistoryOptionButton>
+      </HistoryOptionPanel>
     </>
   );
 };

--- a/src/components/Search/InstantSearchResult.tsx
+++ b/src/components/Search/InstantSearchResult.tsx
@@ -4,6 +4,7 @@ import { View } from 'libreact/lib/View';
 import { WindowWidthQuery } from 'libreact/lib/WindowWidthQuery';
 import { lineClamp, RIDITheme } from 'src/styles';
 import styled from '@emotion/styled';
+import * as colors from '@ridi/colors';
 import { getEscapedString } from 'src/utils/highlight';
 import { BreakPoint, greaterThanOrEqualTo, orBelow } from 'src/utils/mediaQuery';
 import {
@@ -22,7 +23,8 @@ const listItemCSS = css`
   )};
   cursor: pointer;
 `;
-const bookListItemCSS = (theme: RIDITheme) => css`
+
+const BookListItem = styled.li`
   ${listItemCSS};
   ${orBelow(
     BreakPoint.LG,
@@ -48,22 +50,22 @@ const bookListItemCSS = (theme: RIDITheme) => css`
         }
 
         :hover {
-          background-color: ${theme.instantSearch.itemHover};
+          background-color: ${colors.lightSteelBlue5};
         }
       `,
   )}
     :hover {
-    background-color: ${theme.instantSearch.itemHover};
+    background-color: ${colors.lightSteelBlue5};
   }
   button {
     :focus {
-      background-color: ${theme.instantSearch.itemHover};
+      background-color: ${colors.lightSteelBlue5};
       outline: none !important;
     }
   }
 `;
 
-const authorListItemCSS = (theme: RIDITheme) => css`
+const AuthorListItem = styled.li`
   ${listItemCSS};
   display: flex;
   ${orBelow(
@@ -87,24 +89,136 @@ const authorListItemCSS = (theme: RIDITheme) => css`
     `,
   )};
   :hover {
-    background-color: ${theme.instantSearch.itemHover};
+    background-color: ${colors.lightSteelBlue5};
   }
   button {
     :focus {
-      background-color: ${theme.instantSearch.itemHover};
+      background-color: ${colors.lightSteelBlue5};
       outline: none !important;
     }
   }
 `;
 
-const titleCSS = css`
+const AuthorListItemButton = styled.button`
+  width: 100%;
+  height: 100%;
+  padding: 13px 16px;
+  text-align: left;
+  flex-wrap: wrap;
+`;
+
+const BookListItemButton = styled.button`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  text-align: left;
+  padding: 14px 16px;
+`;
+
+const BookThumbnail = styled.img`
+  margin-right: 12px;
+  border: 1px solid ${colors.slateGray30};
+  flex-shrink: 0;
+  width: 38px;
+`;
+
+const BookMeta = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  text-align: left;
+  justify-content: center;  
+`;
+
+const BookTitle = styled.span`
   font-size: 15px;
   line-height: 1.33;
   word-break: keep-all;
+  margin-right: 4px;
+  margin-bottom: 3px;
+  color: #252525; 
+  ${greaterThanOrEqualTo(
+    BreakPoint.LG + 1,
+    css`
+      max-width: 298px;
+      color: #303538;
+      margin-bottom: 4px;
+    `,
+  )};
+`;
+
+const BookAuthors = styled.div`
+  word-break: keep-all;
+  ${greaterThanOrEqualTo(
+    BreakPoint.LG + 1,
+    css`
+      max-width: 298px;
+    `,
+  )}
+`;
+
+const authorPublisherCSS = css`
+  font-size: 14px;
+  line-height: 1.36;
+  color: #808991;
+  -webkit-font-smoothing: antialiased;
+  max-width: 298px;
+`;
+
+const AuthorInfoWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+`;
+
+const AuthorName = styled.span`
+  font-size: 15px;
+  line-height: 1.33;
+  flex-shrink: 0;
+  margin-right: 8px;
+  ${orBelow(
+    BreakPoint.LG,
+    css`
+      margin-right: 3px;
+    `,
+  )};
+  color: #303538;
+`;
+
+const AuthorBooksInfo = styled.span`
+  font-size: 14px;
+  word-break: keep-all;
+  color: ${colors.slateGray50};
+  ${lineClamp(1)};
+`;
+
+const Author = styled.span`
+  ${authorPublisherCSS};
+  margin-right: 4px;
+`;
+
+const AuthorPublisher = styled.span`
+  ${authorPublisherCSS};
+  padding-left: 4px;
+  border-left: 1px solid #e6e8eb;
+  ${greaterThanOrEqualTo(
+    BreakPoint.LG + 1,
+    css`
+      max-width: 298px;
+    `,
+  )}
 `;
 
 const ItemWrapper = styled.div`
   display: flex;
+`;
+
+const InstantSearchDivider = styled.hr`
+  height: 1px;
+  border: 0;
+  border-top: 1px solid #e6e8e0;
+  margin: 8px 16px;
 `;
 
 interface InstantSearchResultProps {
@@ -125,54 +239,19 @@ const AuthorInfo: React.FC<{ author: InstantSearchAuthorResultScheme }> = (props
   const { author } = props;
 
   return (
-    <div
-      css={css`
-        display: flex;
-        align-items: center;
-        width: 100%;
-      `}
-    >
-      <span
-        css={css`
-          font-size: 15px;
-          line-height: 1.33;
-          flex-shrink: 0;
-          ${orBelow(
-          BreakPoint.LG,
-          css`
-              margin-right: 3px;
-            `,
-        )};
-          margin-right: 8px;
-          color: #303538;
-        `}
+    <AuthorInfoWrapper>
+      <AuthorName
         dangerouslySetInnerHTML={{
           __html: getEscapedString(author.highlight.name_raw || author.name_raw),
         }}
       />
-      <span
-        css={(theme: RIDITheme) => css`
-          font-size: 14px;
-          word-break: keep-all;
-          color: ${theme.label2};
-          ${lineClamp(1)};
-        `}
-      >
-        {`<${author.popular_book_title}>${
-          author.book_count > 1 ? ` 외 ${author.book_count - 1}권` : ''
-        }`}
-      </span>
-    </div>
+      <AuthorBooksInfo>
+        {`<${author.popular_book_title}>`}
+        {author.book_count > 1 ? ` 외 ${author.book_count - 1}권` : ''}
+      </AuthorBooksInfo>
+    </AuthorInfoWrapper>
   );
 };
-
-const authorPublisherCSS = css`
-  font-size: 14px;
-  line-height: 1.36;
-  color: #808991;
-  -webkit-font-smoothing: antialiased;
-  max-width: 298px;
-`;
 
 // Todo 사용 컴포넌트마다 다른 options 사용해서 보여주기
 const AuthorLabel: React.FC<{ author: string; authors: AuthorInfoScheme[] }> = (props) => {
@@ -182,28 +261,18 @@ const AuthorLabel: React.FC<{ author: string; authors: AuthorInfoScheme[] }> = (
       .map((author) => author.name);
   if (!viewedAuthors || viewedAuthors.length === 0) {
     return (
-      <span
-        css={css`
-          ${authorPublisherCSS};
-          margin-right: 4px;
-        `}
-      >
+      <Author>
         {props.author}
-      </span>
+      </Author>
     );
   }
 
   return (
-    <span
-      css={css`
-        ${authorPublisherCSS};
-        margin-right: 4px;
-      `}
-    >
+    <Author>
       {viewedAuthors.length > 2
         ? `${viewedAuthors[0]} 외 ${viewedAuthors.length - 1}명`
         : `${viewedAuthors.join(', ')}`}
-    </span>
+    </Author>
   );
 };
 
@@ -214,30 +283,16 @@ const BookList: React.FC<InstantSearchResultBookListProps> = React.memo((props) 
     <>
       <ul>
         {result.books.map((book: InstantSearchBookResultScheme, index) => (
-          <li data-book-id={book.b_id} css={bookListItemCSS} key={index}>
-            <button
-              css={css`
-                height: 100%;
-                width: 100%;
-                display: flex;
-                flex-wrap: wrap;
-                //align-items: center;
-                text-align: left;
-                padding: 14px 16px;
-              `}
+          <BookListItem data-book-id={book.b_id} key={index}>
+            <BookListItemButton
+              type="button"
               data-book-id={book.b_id}
               onKeyDown={handleKeyDown}
               onClick={handleClickBookItem}
             >
               <WindowWidthQuery>
                 <View maxWidth={1000}>
-                  <span
-                    css={css`
-                      ${titleCSS};
-                      margin-right: 4px;
-                      margin-bottom: 3px;
-                      color: #252525;
-                    `}
+                  <BookTitle
                     dangerouslySetInnerHTML={{
                       __html: getEscapedString(
                         book.highlight.web_title_title_raw || book.web_title_title_raw,
@@ -245,95 +300,34 @@ const BookList: React.FC<InstantSearchResultBookListProps> = React.memo((props) 
                     }}
                   />
                   <AuthorLabel author={book.author} authors={book.authors_info} />
-                  <span
-                    css={css`
-                      ${authorPublisherCSS};
-                      padding-left: 4px;
-                      border-left: 1px solid #e6e8eb;
-                      ${greaterThanOrEqualTo(
-                      BreakPoint.LG + 1,
-                      css`
-                          max-width: 298px;
-                        `,
-                    )}
-                    `}
-                  >
-                    {book.publisher}
-                  </span>
+                  <AuthorPublisher>{book.publisher}</AuthorPublisher>
                 </View>
                 <View>
-                  <div>
-                    <ItemWrapper>
-                      <img
-                        alt={book.web_title_title}
-                        css={(theme: RIDITheme) => css`
-                          margin-right: 12px;
-                          border: 1px solid ${theme.image.border};
-                          flex-shrink: 0;
-                          width: 38px;
-                        `}
-                        width="38px"
-                        height="58px"
-                        src={`https://img.ridicdn.net/cover/${book.b_id}/small`}
+                  <ItemWrapper>
+                    <BookThumbnail
+                      alt={book.web_title_title}
+                      width="38px"
+                      height="58px"
+                      src={`https://img.ridicdn.net/cover/${book.b_id}/small`}
+                    />
+                    <BookMeta>
+                      <BookTitle
+                        dangerouslySetInnerHTML={{
+                          __html: getEscapedString(
+                            book.highlight.web_title_title_raw || book.web_title_title_raw,
+                          ),
+                        }}
                       />
-                      <div
-                        css={css`
-                          display: flex;
-                          flex-direction: column;
-                          align-items: start;
-                          text-align: left;
-                          justify-content: center;
-                        `}
-                      >
-                        <p
-                          css={css`
-                            ${titleCSS};
-                            color: #303538;
-                            margin-bottom: 4px;
-                            word-break: keep-all;
-                            ${greaterThanOrEqualTo(
-                            BreakPoint.LG + 1,
-                            css`
-                                max-width: 298px;
-                              `,
-                          )}
-                          `}
-                          dangerouslySetInnerHTML={{
-                            __html: getEscapedString(
-                              book.highlight.web_title_title_raw
-                                || book.web_title_title_raw,
-                            ),
-                          }}
-                        />
-                        <div
-                          css={css`
-                            word-break: keep-all;
-                            ${greaterThanOrEqualTo(
-                            BreakPoint.LG + 1,
-                            css`
-                                max-width: 298px;
-                              `,
-                          )}
-                          `}
-                        >
-                          <AuthorLabel author={book.author} authors={book.authors_info} />
-                          <span
-                            css={css`
-                              ${authorPublisherCSS};
-                              padding-left: 4px;
-                              border-left: 1px solid #e6e8eb;
-                            `}
-                          >
-                            {book.publisher}
-                          </span>
-                        </div>
-                      </div>
-                    </ItemWrapper>
-                  </div>
+                      <BookAuthors>
+                        <AuthorLabel author={book.author} authors={book.authors_info} />
+                        <AuthorPublisher>{book.publisher}</AuthorPublisher>
+                      </BookAuthors>
+                    </BookMeta>
+                  </ItemWrapper>
                 </View>
               </WindowWidthQuery>
-            </button>
-          </li>
+            </BookListItemButton>
+          </BookListItem>
         ))}
       </ul>
     </>
@@ -367,15 +361,9 @@ const InstantSearchResult: React.FC<InstantSearchResultProps> = React.memo((prop
         <>
           <ul>
             {result.authors.map((author, index) => (
-              <li css={authorListItemCSS} key={index}>
-                <button
-                  css={css`
-                    width: 100%;
-                    height: 100%;
-                    padding: 13px 16px;
-                    text-align: left;
-                    flex-wrap: wrap;
-                  `}
+              <AuthorListItem key={index}>
+                <AuthorListItemButton
+                  type="button"
                   data-author-id={author.id}
                   onKeyDown={handleKeyDown}
                   onClick={handleClickAuthorItem}
@@ -385,25 +373,16 @@ const InstantSearchResult: React.FC<InstantSearchResultProps> = React.memo((prop
                       <AuthorInfo author={author} />
                     </View>
                     <View>
-                      <div>
-                        <ItemWrapper>
-                          <AuthorInfo author={author} />
-                        </ItemWrapper>
-                      </div>
+                      <ItemWrapper>
+                        <AuthorInfo author={author} />
+                      </ItemWrapper>
                     </View>
                   </WindowWidthQuery>
-                </button>
-              </li>
+                </AuthorListItemButton>
+              </AuthorListItem>
             ))}
           </ul>
-          <hr
-            css={css`
-              height: 1px;
-              border: 0;
-              border-top: 1px solid #e6e8e0;
-              margin: 8px 16px;
-            `}
-          />
+          <InstantSearchDivider />
         </>
       )}
       {result.books.length > 0 && (


### PR DESCRIPTION
Instant Search의 검색 결과 및 히스토리 컴포넌트의 스타일을 좀 정리했습니다.

- 불필요한 div 엘리먼트를 삭제했습니다.
- 테마쪽은 현재 따로 연관이 없어 보여서 삭제 했습니다.
- 인라인 css를 styled-component로 변경하고 공통되는 부분을 묶었습니다.
