### PR TITLE
hotfix: RankingBookList 에서는 태그를 늘 표시하지 않음.

### DIFF
--- a/src/components/BookSections/RankingBook/RankingBookList.tsx
+++ b/src/components/BookSections/RankingBook/RankingBookList.tsx
@@ -278,7 +278,7 @@ const ItemList: React.FC<any> = (props) => {
                   titleLineClamp={props.type === 'small' ? 1 : 2}
                   isAIRecommendation={false}
                   showSomeDeal={showSomeDeal}
-                  showTag={['bl', 'bl-serial'].includes(genre) && props.type === 'big'}
+                  showTag={false}
                   width={props.type === 'big' ? '177px' : null}
                   ratingInfo={(book as MdBook).rating}
                 />


### PR DESCRIPTION
https://app.asana.com/0/947013990327604/1155730896793139
### BL, BL 연재 홈
베스트셀러, 지많읽(RankingBookList) 에 태그 표시 제거
