### PR TITLE
circle ci cache key 변경

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - <<parameters.key>>-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - <<parameters.key>>-{{ .Branch }}-
+            - <<parameters.key>>-{{ .Branch }}--{{ checksum "yarn.lock" }}
+            - <<parameters.key>>-{{ .Branch }}--
             - <<parameters.key>>-
       - run:
           name: Install yarn packages
           command: yarn install --frozen-lockfile
       - save_cache:
-          key: <<parameters.key>>-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: <<parameters.key>>-{{ .Branch }}--{{ checksum "yarn.lock" }}
           paths: ~/.cache/yarn
   notify:
     parameters:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ```
 
 [![codecov](https://codecov.io/gh/ridi/books-frontend/branch/master/graph/badge.svg)](https://codecov.io/gh/ridi/books-frontend)
+[![CircleCI](https://circleci.com/gh/ridi/books-frontend/tree/master.svg?style=svg)](https://circleci.com/gh/ridi/books-frontend/tree/master)
 
 ## Infrastructure
 


### PR DESCRIPTION
다음 패키지를 CircleCI ssh 에서 수동으로 설치하면 빌드는 성공합니다.
```sh
yarn add -D @types/react @types/node typescript babel-plugin-module-resolver @babel/plugin-proposal-optional-chaining @babel/plugin-proposal-nullish-coalescing-operator @emotion/babel-preset-css-prop @svgr/webpack
```

현재 CircleCI master 빌드가 실패하고 있고 패키지 캐시가 문제가 있지 않을까 해서 변경 해봅니다.
