### PR TITLE
SelectionBookList 가 스크롤링 됐을 때 BookMeta가 제대로 표시 되지 않는 부분 수정

### DIFF
--- a/src/components/BookSections/SelectionBook/SelectionBookList.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookList.tsx
@@ -2,7 +2,9 @@ import React, {
   useContext, useEffect, useRef, useState,
 } from 'react';
 import { displayNoneForTouchDevice, flexRowStart, scrollBarHidden } from 'src/styles';
-import { SelectionBookItem, SelectionBookLoading } from 'src/components/BookSections/SelectionBook/SelectionBook';
+import {
+  SelectionBookItem,
+} from 'src/components/BookSections/SelectionBook/SelectionBook';
 import { css } from '@emotion/core';
 import { between, BreakPoint, orBelow } from 'src/utils/mediaQuery';
 import Arrow, { arrowTransition } from 'src/components/Carousel/Arrow';
@@ -119,17 +121,8 @@ const SelectionBookList: React.FC<SelectionBookListProps> = React.memo((props) =
   }, []);
 
   if (!isMounted) {
-    // Flickering 없는 UI 를 위해 추가함
-    return (
-      <SelectionBookLoading
-        genre={genre}
-        type={type}
-        isAIRecommendation={props.isAIRecommendation}
-        items={props.items.slice(0, 6)}
-      />
-    );
+    return null;
   }
-
   return (
     <div
       css={css`

--- a/src/components/BookSections/SelectionBook/SelectionBookList.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookList.tsx
@@ -1,6 +1,8 @@
-import React, { useContext, useRef } from 'react';
+import React, {
+  useContext, useEffect, useRef, useState,
+} from 'react';
 import { displayNoneForTouchDevice, flexRowStart, scrollBarHidden } from 'src/styles';
-import { SelectionBookItem } from 'src/components/BookSections/SelectionBook/SelectionBook';
+import { SelectionBookItem, SelectionBookLoading } from 'src/components/BookSections/SelectionBook/SelectionBook';
 import { css } from '@emotion/core';
 import { between, BreakPoint, orBelow } from 'src/utils/mediaQuery';
 import Arrow, { arrowTransition } from 'src/components/Carousel/Arrow';
@@ -110,6 +112,23 @@ const SelectionBookList: React.FC<SelectionBookListProps> = React.memo((props) =
   const deviceType = useContext(DeviceTypeContext);
   // @ts-ignore
   const [requestExclude, requestCancel] = useExcludeRecommendation();
+  const [isMounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    window.setImmediate(() => setMounted(true));
+  }, []);
+
+  if (!isMounted) {
+    // Flickering 없는 UI 를 위해 추가함
+    return (
+      <SelectionBookLoading
+        genre={genre}
+        type={type}
+        isAIRecommendation={props.isAIRecommendation}
+        items={props.items.slice(0, 6)}
+      />
+    );
+  }
 
   return (
     <div

--- a/src/components/BookSections/SelectionBook/SelectionBookList.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookList.tsx
@@ -112,7 +112,6 @@ const SelectionBookList: React.FC<SelectionBookListProps> = React.memo((props) =
   const [moveLeft, moveRight, isOnTheLeft, isOnTheRight] = useScrollSlider(ref);
   const { genre, type, slug } = props;
   const deviceType = useContext(DeviceTypeContext);
-  // @ts-ignore
   const [requestExclude, requestCancel] = useExcludeRecommendation();
   const [isMounted, setMounted] = useState(false);
 

--- a/src/tests/components/BookSelections/SelectionBook.spec.tsx
+++ b/src/tests/components/BookSelections/SelectionBook.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { act, render, cleanup, getAllByAltText, RenderResult, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-// @ts-ignore
 import { ThemeProvider } from 'emotion-theming';
 import { Provider } from 'react-redux';
 import SelectionBookList from 'src/components/BookSections/SelectionBook/SelectionBookList';

--- a/src/tests/components/BookSelections/SelectionBook.spec.tsx
+++ b/src/tests/components/BookSelections/SelectionBook.spec.tsx
@@ -70,8 +70,6 @@ describe('test SelectionBookContainer', () => {
   it('should be render SelectionBookList item', async () => {
     const { container } = actRender(renderSelectionBookList);
     const item = await waitForElement(() => getAllByAltText(container, '도서 표지'));
-
-
     expect(item).not.toBe(null);
   });
 });

--- a/src/tests/components/BookSelections/SelectionBook.spec.tsx
+++ b/src/tests/components/BookSelections/SelectionBook.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, render, cleanup, getAllByAltText, RenderResult } from '@testing-library/react';
+import { act, render, cleanup, getAllByAltText, RenderResult, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 // @ts-ignore
 import { ThemeProvider } from 'emotion-theming';
@@ -67,9 +67,11 @@ describe('test SelectionBookContainer', () => {
     window.IntersectionObserver = originalIO;
   });
 
-  it('should be render SelectionBookList item', () => {
+  it('should be render SelectionBookList item', async () => {
     const { container } = actRender(renderSelectionBookList);
-    const itemNode = getAllByAltText(container, '도서 표지');
-    expect(itemNode).not.toBe(null);
+    const item = await waitForElement(() => getAllByAltText(container, '도서 표지'));
+
+
+    expect(item).not.toBe(null);
   });
 });


### PR DESCRIPTION
### 증상
![image](https://user-images.githubusercontent.com/45959991/75863349-a6a6f200-5e43-11ea-932d-0cba264093c3.png)

react-slick 캐러셀이 항상 먼저 그려지다보니 `SelectionBookLoading` 을 꼭 한 번은 그리게 되는데 그 이후 올바른 렌더링이 안되는 거 같습니다. 
  
그것에 대한 임시 수정입니다. 