### PR TITLE
개발 환경에서 CSP 설정 수정, report-uri 주석 처리

### DIFF
--- a/src/components/Meta/CSP.tsx
+++ b/src/components/Meta/CSP.tsx
@@ -39,6 +39,7 @@ export default () => {
 
   if (!process.env.IS_PRODUCTION) {
     scriptSrc.push("'unsafe-eval'");
+    scriptSrc.push("'unsafe-inline'");
   } else {
     // styleSrc.push(nonce);
   }
@@ -67,7 +68,8 @@ export default () => {
             ...thirdPartyVendors,
             ...whiteList,
           ],
-          'report-uri': `https://sentry.io/api/1402572/security/?sentry_key=a0a997382844435fa6c89803ef6ce8e5&sentry_environment=${process.env.STAGE};`,
+          // <meta/> 에서 report-uri 는 동작하지 않습니다. https://developers.google.com/web/fundamentals/security/csp?hl=ko
+          // 'report-uri': `https://sentry.io/api/1402572/security/?sentry_key=a0a997382844435fa6c89803ef6ce8e5&sentry_environment=${process.env.STAGE};`,
         },
       })}
     />

--- a/src/tests/components/Meta/Meta.spec.tsx
+++ b/src/tests/components/Meta/Meta.spec.tsx
@@ -5,7 +5,6 @@ import CSP from 'src/components/Meta/CSP';
 import { render, cleanup, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-
 describe('testing Meta & Head', () => {
   afterEach(cleanup);
 

--- a/src/tests/components/Meta/Meta.spec.tsx
+++ b/src/tests/components/Meta/Meta.spec.tsx
@@ -23,6 +23,3 @@ describe('testing Meta & Head', () => {
   });
 
 });
-
-
-

--- a/src/tests/components/Meta/Meta.spec.tsx
+++ b/src/tests/components/Meta/Meta.spec.tsx
@@ -1,10 +1,28 @@
 import * as React from 'react';
 import Meta from 'src/components/Meta';
-import { render, cleanup } from '@testing-library/react';
+import CSP from 'src/components/Meta/CSP';
+
+import { render, cleanup, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-afterEach(cleanup);
 
-test('should be render Index Component', () => {
-  render(<Meta />);
+describe('testing Meta & Head', () => {
+  afterEach(cleanup);
+
+  it('should be render Meta Component', async () => {
+    const { container } = render(<Meta />);
+
+    expect(container).not.toBe(null);
+  });
+
+  it('should be render CSP meta', async () => {
+    const { container } = render(<CSP />);
+    const meta = await waitForElement(() => container, { container });
+    const cspMeta = meta.querySelector('meta');
+    expect(cspMeta.httpEquiv).toBe('Content-Security-Policy');
+  });
+
 });
+
+
+


### PR DESCRIPTION
둘 다 임시적인 수정인 것 같긴 한데요 ...


- report-uri 속성은 `<meta/>` 에서는 동작하지 않습니다.
https://developers.google.com/web/fundamentals/security/csp?hl=ko
`report-uri 은 콘텐츠 보안 정책 위반 시 브라우저가 보고서를 보낼 URL을 지정합니다. <meta> 태그에서는 이 지시문을 사용할 수 없습니다.`

- 개발할 때 next.js 에서 unsafe-inline script 를 실행하는데 CSP 에서 걸립니다. 수정하려면 다시 nonce 를 사용하면 됩니다.
