### PR TITLE
라이트 하우스 CI 를 CircleCI Schedule job 으로 변경

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,37 @@ jobs:
             node ~/books-frontend/profile/live.js '<< parameters.url >>'
       - store_artifacts:
           path: /tmp/traces
+  lhci:
+    docker:
+      - image: circleci/node:10.16-browsers
+    working_directory: ~/books-frontend
+    parameters:
+      url:
+        type: string
+        default: https://ridibooks.com/
+      lhci-github-app-token:
+        type: env_var_name
+        default: LHCI_GITHUB_APP_TOKEN
+      lhci-server-base-url:
+        type: env_var_name
+        default: LHCI_SERVER_BASE_URL
+      lhci-project-token:
+        type: env_var_name
+        default: LHCI_PROJECT_TOKEN
+    steps:
+      - checkout
+      - run:
+          name: run lhci
+          command: |
+            yarn add @lhci/cli
+            echo << parameters.lhci-server-base-url >>
+            echo << parameters.lhci-project-token >>
+            echo ${<< parameters.lhci-server-base-url >>}
+            echo ${<< parameters.lhci-project-token >>}
+            ./node_modules/.bin/lhci autorun
+            ./node_modules/.bin/lhci upload --serverBaseUrl=${LHCI_SERVER_BASE_URL} --target lhci --token ${LHCI_PROJECT_TOKEN}
+      - store_artifacts:
+          path: /tmp/lhci
   rollback:
     docker:
       - image: circleci/node:lts
@@ -233,3 +264,14 @@ workflows:
             - notify:
                 color: '#805b24'
                 rollback: true
+  nightly:
+    triggers:
+      - schedule:
+          cron: "* * * * *"
+          filters:
+            branches:
+              only:
+                - fix/lighthouse-ci
+    jobs:
+      - lhci:
+          name: Lighthouse-CI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
           path: /tmp/traces
   lhci:
     docker:
-      - image: circleci/node:10.16-browsers
+      - image: circleci/node:lts-browsers
     working_directory: ~/books-frontend
     parameters:
       url:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,10 @@ workflows:
           requires:
             - deploy-prod
           url: https://ridibooks.com/
+      - lhci:
+          name: Lighthouse-CI
+          requires:
+            - deploy-prod
       - rollback-approval:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,13 +171,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: run lhci
+          name: Run Lighthouse CI
           command: |
             yarn add @lhci/cli
-            echo << parameters.lhci-server-base-url >>
-            echo << parameters.lhci-project-token >>
-            echo ${<< parameters.lhci-server-base-url >>}
-            echo ${<< parameters.lhci-project-token >>}
             ./node_modules/.bin/lhci autorun
             ./node_modules/.bin/lhci upload --serverBaseUrl=${LHCI_SERVER_BASE_URL} --target lhci --token ${LHCI_PROJECT_TOKEN}
       - store_artifacts:
@@ -267,11 +263,11 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "* * * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
-                - fix/lighthouse-ci
+                - master
     jobs:
       - lhci:
           name: Lighthouse-CI


### PR DESCRIPTION
Github Actions 에서 cronjob 안도는 이유는 정확하게는 모르겠습니다 ...
CircleCI 잡은 돌아가는 거 같아 작업중입니다.

master 커밋 해시가 그대로라면 서버에 업데이트 되지 않습니다.

LH CI Server
http://ridi-lhci.ap-northeast-2.elasticbeanstalk.com/app/projects/books-frontend


- UTC 00:00 에 돌아갑니다.
- deploy-prod 된 후 돌아갑니다.
