### PR TITLE
LH audit 에 일반장르 제외 bl, bl 연재 추가

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,10 +3,11 @@
     "collect": {
       "numberOfRuns": 3,
       "url": [
-        "https://ridibooks.com",
         "https://ridibooks.com/fantasy",
         "https://ridibooks.com/comics",
-        "https://ridibooks.com/romance"
+        "https://ridibooks.com/romance",
+        "https://ridibooks.com/bl",
+        "https://ridibooks.com/bl-serial"
       ]
     },
     "assert": {


### PR DESCRIPTION
일반장르 audit 은 제외하고 노출 도서가 많은
 - `https://ridibooks.com/bl` 
 - `https://ridibooks.com/bl-serial`
을 추가했습니다.
