### PR TITLE
장르 홈에서 SPA로 페이징 시 전환 속도 향상

### DIFF
--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -17,8 +17,7 @@ import { useRouter } from 'next/router';
 import DoublePointIcon from 'src/svgs/DoublePoint.svg';
 import CashIcon from 'src/svgs/Cash.svg';
 import pRetry from 'p-retry';
-import axios, { OAuthRequestType, wrapCatchCancel } from 'src/utils/axios';
-import originalAxios from 'axios';
+import axios, { CancelToken, OAuthRequestType, wrapCatchCancel } from 'src/utils/axios';
 import sentry from 'src/utils/sentry';
 
 const { captureException } = sentry();
@@ -200,7 +199,7 @@ const GNBButtons: React.FC<GNBButtonsProps> = (props) => {
 
   const route = useRouter();
   useEffect(() => {
-    const source = originalAxios.CancelToken.source();
+    const source = CancelToken.source();
 
     const requestRidiEventStatus = async () => {
       try {
@@ -224,9 +223,7 @@ const GNBButtons: React.FC<GNBButtonsProps> = (props) => {
     };
     requestRidiEventStatus();
 
-    return () => {
-      source.cancel();
-    };
+    return source.cancel;
   }, [route]);
 
   return (
@@ -353,11 +350,9 @@ export const GNB: React.FC<GNBProps> = React.memo((props: GNBProps) => {
   }, [route.asPath, route.query.origin]);
 
   useEffect(() => {
-    const cancelToken = originalAxios.CancelToken.source();
-    dispatch({ type: accountActions.checkLogged.type, payload: cancelToken });
-    return () => {
-      cancelToken.cancel();
-    };
+    const source = CancelToken.source();
+    dispatch({ type: accountActions.checkLogged.type, payload: source });
+    return source.cancel;
   }, []);
 
   return (

--- a/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
+++ b/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
@@ -480,7 +480,7 @@ const HomeKeywordFinderSection: React.FC<HomeKeywordFinderSectionProps> = (props
     genreSearchParam.append('from', genre);
   }
 
-  return (
+  return genreKeywords ? (
     <Section>
       <SectionTitle aria-label="키워드 파인더로 이동">
         <a
@@ -550,7 +550,7 @@ const HomeKeywordFinderSection: React.FC<HomeKeywordFinderSectionProps> = (props
         </form>
       )}
     </Section>
-  );
+  ) : null;
 };
 
 export default HomeKeywordFinderSection;

--- a/src/components/Tabs/GenreTab.tsx
+++ b/src/components/Tabs/GenreTab.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router';
 import * as Cookies from 'js-cookie';
 import * as colors from '@ridi/colors';
 import { safeJSONParse } from 'src/utils/common';
+import Link from 'next/link';
 
 const GenreTabWrapper = styled.ul`
   max-width: 1000px;
@@ -110,6 +111,10 @@ const SubServicesList = styled.ul`
   li {
     height: 100%;
     line-height: 50px;
+    button {
+      font-size: 17px;
+      ${clearOutline};
+    }
     a {
       font-size: 17px;
       ${clearOutline};
@@ -175,7 +180,7 @@ const GenreTabDivider = styled.hr`
 interface TabItemProps {
   label: string;
   activePath: RegExp;
-  route?: string;
+  href: string;
 }
 
 const subGenres: { [genre: string]: Array<{ name: string; path: string; activePaths: RegExp }> } = {
@@ -195,7 +200,7 @@ const subGenres: { [genre: string]: Array<{ name: string; path: string; activePa
 
 const TabItem: React.FC<TabItemProps> = (props) => {
   const router = useRouter();
-  const { route, activePath, label } = props;
+  const { href, activePath, label } = props;
   const [isActivePath, setIsActivePath] = useState(false);
   const cookieGenre = Cookies.get('main_genre') || '';
 
@@ -207,17 +212,26 @@ const TabItem: React.FC<TabItemProps> = (props) => {
     <li
       css={isActivePath ? activeLabelCSS : genreLabelCSS}
     >
-      <a
-        aria-label={label}
-        href={route}
-        onClick={() => {
-          if (route === '/' && cookieGenre) {
-            Cookies.set('main_genre', '', { sameSite: 'lax' });
-          }
-        }}
-      >
-        {isActivePath ? <ActiveText>{label}</ActiveText> : <span>{label}</span>}
-      </a>
+      {process.env.IS_PRODUCTION ? (
+        <a
+          aria-label={label}
+          href={href}
+          onClick={() => {
+            if (href === '/' && cookieGenre) {
+              Cookies.set('main_genre', '', { sameSite: 'lax' });
+            }
+          }}
+        >
+          {isActivePath ? <ActiveText>{label}</ActiveText> : <span>{label}</span>}
+        </a>
+      ) : (
+        <Link href={href === '/' ? '/' : '/[genre]'} as={href}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a aria-label={label}>
+            {isActivePath ? <ActiveText>{label}</ActiveText> : <span>{label}</span>}
+          </a>
+        </Link>
+      )}
     </li>
   );
 };
@@ -282,27 +296,27 @@ const GenreTab: React.FC<GenreTabProps> = React.memo((props) => {
             <TabItem
               activePath={/^\/?$/}
               label="일반"
-              route="/"
+              href="/"
             />
             <TabItem
               activePath={/^\/romance(-serial)?\/?$/}
               label="로맨스"
-              route={subServices.romance || '/romance'}
+              href={subServices.romance || '/romance'}
             />
             <TabItem
               activePath={/^\/fantasy(-serial)?\/?$/}
               label="판타지"
-              route={subServices.fantasy || '/fantasy'}
+              href={subServices.fantasy || '/fantasy'}
             />
             <TabItem
               activePath={/^\/comics\/?$/}
               label="만화"
-              route="/comics"
+              href="/comics"
             />
             <TabItem
               activePath={/^\/bl(-serial)?\/?$/}
               label="BL"
-              route={subServices.bl || '/bl'}
+              href={subServices.bl || '/bl'}
             />
           </GenreList>
         </li>
@@ -315,7 +329,7 @@ const GenreTab: React.FC<GenreTabProps> = React.memo((props) => {
               {subGenreData.map((service, index) => (
                 <TabItem
                   key={index}
-                  route={service.path}
+                  href={service.path}
                   activePath={service.activePaths}
                   label={service.name}
                 />

--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -1,12 +1,13 @@
-import React, { useCallback, useEffect } from 'react';
+import React, {
+  useState, useCallback, useEffect, useRef,
+} from 'react';
 import Head from 'next/head';
 import { ConnectedInitializeProps } from 'src/types/common';
 import { GenreTab } from 'src/components/Tabs';
 import cookieKeys, { DEFAULT_COOKIE_EXPIRES } from 'src/constants/cookies';
-import Router from 'next/router';
 import * as Cookies from 'js-cookie';
 import titleGenerator from 'src/utils/titleGenerator';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { Page, Section } from 'src/types/sections';
 import { HomeSectionRenderer } from 'src/components/Section/HomeSectionRenderer';
@@ -15,13 +16,11 @@ import { keyToArray } from 'src/utils/common';
 import axios from 'src/utils/axios';
 import { booksActions } from 'src/services/books';
 import { Request } from 'express';
-import { ServerResponse } from 'http';
 import sentry from 'src/utils/sentry';
 import { categoryActions } from 'src/services/category';
 import { NextPage } from 'next';
 import { useEventTracker } from 'src/hooks/useEventTracker';
 import { RootState } from 'src/store/config';
-import useIsSelectFetch from 'src/hooks/useIsSelectFetch';
 import { css } from '@emotion/core';
 
 import { DeviceType } from 'src/components/Context/DeviceType';
@@ -74,12 +73,47 @@ const setCookie = (genre: string) => {
   });
 };
 
+const usePrevious = <T extends {}>(value: T) => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
 export const Home: NextPage<HomeProps> = (props) => {
   const { loggedUser } = useSelector((state: RootState) => state.account);
-  const bIds = keyToArray(
-    props.branches.filter((section) => section.extra.use_select_api),
-    'b_id',
-  );
+  const dispatch = useDispatch();
+
+  const [branches, setBranches] = useState(props.branches);
+  const previousGenre = usePrevious(props.genre);
+  useEffect(() => {
+    const fetch = async () => {
+      if (!branches || previousGenre !== props.genre) {
+        // store.dispatch({ type: booksActions.setFetching.type, payload: true });
+        setBranches([]);
+        const result = await fetchHomeSections(
+          // @ts-ignore
+          props.genre || 'general',
+        );
+        setBranches(result.branches);
+        const bIds = keyToArray(result.branches, 'b_id');
+        dispatch({ type: booksActions.insertBookIds.type, payload: bIds });
+        const categoryIds = keyToArray(result.branches, 'category_id');
+        dispatch({
+          type: categoryActions.insertCategoryIds.type,
+          payload: categoryIds,
+        });
+        const selectBIds = keyToArray(
+          result.branches.filter((section) => section.extra.use_select_api),
+          'b_id',
+        );
+        dispatch({ type: booksActions.checkSelectBook.type, payload: selectBIds });
+      }
+    };
+    fetch();
+  }, [props.genre, dispatch]);
+
   const [tracker] = useEventTracker();
 
   const setPageView = useCallback(() => {
@@ -92,11 +126,11 @@ export const Home: NextPage<HomeProps> = (props) => {
     }
   }, [tracker]);
 
-  useIsSelectFetch(bIds);
   useEffect(() => {
     setCookie(props.genre);
     setPageView();
-  }, [props.genre, loggedUser, props.branches, setPageView]);
+  }, [props.genre, loggedUser, setPageView]);
+
   const { genre } = props;
   const currentGenre = genre || 'general';
   return (
@@ -106,12 +140,11 @@ export const Home: NextPage<HomeProps> = (props) => {
       </Head>
       <GenreTab currentGenre={currentGenre} />
       <DeviceType>
-        {props.branches
-          && props.branches.map((section, index) => (
-            <React.Fragment key={index}>
-              <HomeSectionRenderer section={section} order={index} genre={currentGenre} />
-            </React.Fragment>
-          ))}
+        {branches && branches.map((section, index) => (
+          <React.Fragment key={index}>
+            <HomeSectionRenderer section={section} order={index} genre={currentGenre} />
+          </React.Fragment>
+        ))}
         <div
           css={css`
             margin-bottom: 24px;
@@ -124,7 +157,11 @@ export const Home: NextPage<HomeProps> = (props) => {
 
 Home.getInitialProps = async (ctx: ConnectedInitializeProps) => {
   const {
-    query, res, req, store,
+    query,
+    res,
+    req,
+    store,
+    isServer,
   } = ctx;
 
   const { genre = 'general' } = query;
@@ -132,7 +169,7 @@ Home.getInitialProps = async (ctx: ConnectedInitializeProps) => {
     throw new Error('Not Found');
   }
 
-  if (req && res) {
+  if (isServer) {
     if (res.statusCode !== 302) {
       try {
         // store.dispatch({ type: booksActions.setFetching.type, payload: true });
@@ -155,44 +192,9 @@ Home.getInitialProps = async (ctx: ConnectedInitializeProps) => {
           ...result,
         };
       } catch (error) {
-        console.log(error);
         captureException(error, ctx);
-        // redirect(req, res, '/error');
+        throw new Error(error);
       }
-    }
-  } else {
-    // Client Side
-    try {
-      const result = await fetchHomeSections(
-        // @ts-ignore
-        genre || 'general',
-        null,
-        // Hack
-        // 사파리 BFCache 디스크에서 캐시 된 데이터가 그대로 사용되는데 끄걸 회피하기 위해 Query Param 에 초를 삽입하는 꼼수
-        // 30초 단위로 잘라 보냄
-        { sec: Math.floor(Date.now() / 30000) },
-      );
-      const bIds = keyToArray(result.branches, 'b_id');
-      store.dispatch({ type: booksActions.insertBookIds.type, payload: bIds });
-      const categoryIds = keyToArray(result.branches, 'category_id');
-      store.dispatch({
-        type: categoryActions.insertCategoryIds.type,
-        payload: categoryIds,
-      });
-      const selectBIds = keyToArray(
-        result.branches.filter((section) => section.extra.use_select_api),
-        'b_id',
-      );
-      store.dispatch({ type: booksActions.checkSelectBook.type, payload: selectBIds });
-      return {
-        genre,
-        store,
-        ...query,
-        ...result,
-      };
-    } catch (error) {
-      captureException(error, ctx);
-      Router.push('/error');
     }
   }
   return {

--- a/src/tests/pages/[genre].spec.tsx
+++ b/src/tests/pages/[genre].spec.tsx
@@ -81,10 +81,7 @@ describe('Home Test', () => {
     });
     expect(handler).toBeCalledTimes(1);
     expect(handler.mock.calls[0][0]).toEqual('get');
-    expect(new URL(handler.mock.calls[0][1])).toHaveProperty(
-      'pathname',
-      '/pages/home-fantasy/',
-    );
+    expect(handler.mock.calls[0][1]).toEqual('/pages/home-fantasy/');
 
     const { queryByText } = await renderComponent({ props, isPartials: false });
     expect(queryByText(/단행본/)).not.toBeNull();

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -12,6 +12,8 @@ export interface CustomRequestConfig {
   authorizationRequestType: OAuthRequestType;
 }
 
+export const { CancelToken } = axios;
+
 // eslint-disable-next-line no-process-env
 const TIME_OUT = 7000;
 

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -1,5 +1,10 @@
 export function createTimeLabel() {
   const date = new Date();
+  date.setHours(
+    date.getHours()
+    + date.getTimezoneOffset() / 60
+    + 9,
+  );
   const hour = date
     .getHours()
     .toString()


### PR DESCRIPTION
장르 홈 컴포넌트가 CSR 될 때 데이터 fetch 를 개선합니다.
장르 탭의 A/Link 태그를 프로덕션/개발 빌드로 분기합니다.