### PR TITLE
TopBanner 흔들림 현상 수정

### DIFF
--- a/src/components/Carousel/BigBannerCarousel.spec.tsx
+++ b/src/components/Carousel/BigBannerCarousel.spec.tsx
@@ -28,12 +28,12 @@ describe('BigBannerCarousel', () => {
   afterAll(cleanup);
 
   const renderImpl: Parameters<typeof BigBannerCarousel>[0]['children'] =
-    ({ index, activeIndex }) => (
+    ({ index, active }) => (
       <div
         key={index}
         className="item"
         data-index={index}
-        data-active={index === activeIndex}
+        data-active={active ? '' : undefined}
       />
     );
 
@@ -41,7 +41,7 @@ describe('BigBannerCarousel', () => {
     const ul = result.container.querySelector('ul');
     const raw = ul.style.transform.split(' ');
     const parsed = raw.map(item => Number(/\(([+-]?\d+(?:\.\d+)?)/.exec(item)[1]));
-    const width = (ITEM_WIDTH + ITEM_MARGIN) * TOTAL_ITEMS * 2;
+    const width = (ITEM_WIDTH + ITEM_MARGIN) * TOTAL_ITEMS * 2 + ITEM_WIDTH;
     const offset = parsed[0] * width + parsed[1] + parsed[2];
     return offset;
   }
@@ -53,9 +53,9 @@ describe('BigBannerCarousel', () => {
       result = render(renderCarousel(renderFn, 0));
     });
     expect(result.container.querySelectorAll('.item'))
-      .toHaveLength(TOTAL_ITEMS * 2);
+      .toHaveLength(TOTAL_ITEMS * 2 + 1);
     expect(result.container.querySelectorAll('.item[data-active][data-index="0"]'))
-      .toHaveLength(2);
+      .toHaveLength(1);
   });
 
   describe('movement', () => {

--- a/src/components/Carousel/BigBannerCarousel.tsx
+++ b/src/components/Carousel/BigBannerCarousel.tsx
@@ -17,11 +17,11 @@ function computeTransform(options: TransformOptions) {
     slideMargin: d,
     touchDiff,
   } = options;
-  const commonDivider = (n - 1) * r + 1;
-  const percentage = (25 + 50 * k * r) / commonDivider;
-  const negPixels = (0.5 * n * d + (r - 1) * d * k) / commonDivider;
+  const commonDivider = 2 * n * r + 1;
+  const percentage = (100 * r * k) / commonDivider;
+  const pixels = (d * k) / commonDivider;
   const touch = touchDiff ?? 0;
-  return `translateX(${-percentage}%) translateX(${negPixels}px) translateX(${touch}px)`;
+  return `translateX(${-percentage}%) translateX(${-pixels}px) translateX(${touch}px)`;
 }
 
 const CarouselView = styled.div`
@@ -39,8 +39,8 @@ const CarouselList = styled.ul<{ slideMargin: number }>`
   flex-wrap: nowrap;
   align-items: center;
 
-  > li {
-    margin-right: ${(props) => props.slideMargin}px;
+  > li + li {
+    margin-left: ${(props) => props.slideMargin}px;
   }
 `;
 
@@ -49,7 +49,7 @@ export interface BigBannerCarouselProps {
   currentIdx: number;
   itemMargin: number;
   inactiveScale: number;
-  children: (props: { index: number; activeIndex: number }) => React.ReactNode;
+  children: (props: { index: number; active: boolean; activeIndex: number }) => React.ReactNode;
   touchDiff?: number;
   className?: string;
 }
@@ -97,8 +97,11 @@ export default function BigBannerCarousel(props: BigBannerCarouselProps) {
     (_, idx) => (idx + previousIdx) % len,
   );
 
+  const itemNodesSub = idxArray.map(
+    (index) => children({ index, active: false, activeIndex: activeIdx }),
+  );
   const itemNodes = idxArray.map(
-    (index) => children({ index, activeIndex: activeIdx }),
+    (index) => children({ index, active: index === activeIdx, activeIndex: activeIdx }),
   );
   let delta = activeIdx - previousIdx;
   if (Math.abs(delta) > Math.abs(delta + len)) {
@@ -123,8 +126,9 @@ export default function BigBannerCarousel(props: BigBannerCarouselProps) {
         }}
         onTransitionEnd={handleTransitionDone}
       >
+        {itemNodesSub}
         {itemNodes}
-        {itemNodes}
+        {children({ index: previousIdx, active: false, activeIndex: activeIdx })}
       </CarouselList>
     </CarouselView>
   );

--- a/src/components/TopBanner.tsx
+++ b/src/components/TopBanner.tsx
@@ -442,11 +442,11 @@ export default function TopBannerCarousel(props: TopBannerCarouselProps) {
         touchDiff={touchDiff}
         css={carouselHeight}
       >
-        {({ index, activeIndex }) => (
+        {({ index, active, activeIndex }) => (
           <CarouselItem
             key={index}
             banner={banners[index]}
-            active={index === activeIndex}
+            active={active}
             invisible={!checkWithinRingRange(
               (activeIndex - SLIDE_RADIUS + len) % len,
               (activeIndex + SLIDE_RADIUS) % len,


### PR DESCRIPTION
데스크탑 초기 렌더 시 제자리 찾아가는 모션이 보이는 현상을 수정합니다.

슬라이드가 `2n + 1`개가 되면서 계산식이 바뀌었습니다.