### PR TITLE
계정팀 내 기기 관리 페이지의 GNB isPartials에 대한 anchor href 서포트

### DIFF
--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -323,6 +323,7 @@ export const GNB: React.FC<GNBProps> = React.memo((props: GNBProps) => {
   const { loggedUser } = useSelector<RootState, AccountState>((state) => state.account);
   const dispatch = useDispatch();
   const route = useRouter();
+  const { isPartials } = props;
 
   const initialLoginPath = `${process.env.NEXT_PUBLIC_ACCOUNT_HOST}/account/login`;
   const initialSignupPath = `${process.env.NEXT_PUBLIC_ACCOUNT_HOST}/account/signup`;
@@ -357,7 +358,7 @@ export const GNB: React.FC<GNBProps> = React.memo((props: GNBProps) => {
             <LogoWrapper>
               <li>
                 <a
-                  href="/"
+                  href={isPartials ? `${process.env.NEXT_PUBLIC_ACCOUNT_HOST}/` : '/'}
                   aria-label="리디북스 홈으로 이동"
                   css={css`
                     display: flex;
@@ -388,6 +389,7 @@ export const GNB: React.FC<GNBProps> = React.memo((props: GNBProps) => {
               />
             </ButtonWrapper>
             <InstantSearch
+              isPartials={isPartials}
               searchKeyword={props.searchKeyword || ''}
             />
           </div>

--- a/src/components/Tabs/MainTab.tsx
+++ b/src/components/Tabs/MainTab.tsx
@@ -160,9 +160,12 @@ const NotificationAddOn = styled.div`
   background: #ffde24;
   border-radius: 11px;
   background-clip: padding-box;
-  ${orBelow(BreakPoint.LG, css`
-    left: 17.5px;
-  `)};
+  ${orBelow(
+    BreakPoint.LG,
+    css`
+      left: 17.5px;
+    `,
+  )};
 `;
 
 const CartAddOnWrapper = styled.div`
@@ -177,9 +180,12 @@ const CartAddOnWrapper = styled.div`
   display: flex;
   max-height: 31px;
   height: 100%;
-  ${orBelow(BreakPoint.LG, css`
-    left: 12.5px;
-  `)};
+  ${orBelow(
+    BreakPoint.LG,
+    css`
+      left: 12.5px;
+    `,
+  )};
 `;
 
 const CartAddOnBackground = styled.div`
@@ -189,9 +195,12 @@ const CartAddOnBackground = styled.div`
   background: white;
   height: 20px;
   display: flex;
-  ${orBelow(BreakPoint.LG, css`
-    margin-left: 4px;
-  `)};
+  ${orBelow(
+    BreakPoint.LG,
+    css`
+      margin-left: 4px;
+    `,
+  )};
   background-clip: padding-box;
 `;
 
@@ -202,7 +211,6 @@ const CartAddOnCount = styled.span`
   line-height: 11.5px;
   color: #1f8ce6;
 `;
-
 
 interface MainTabProps {
   isPartials: boolean;
@@ -228,7 +236,7 @@ interface TabItemProps {
 // 반응형 레거시 코드 작업이 종료되면 이 부분 개선 해야 함.
 const TabItem: React.FC<TabItemProps> = (props) => {
   const {
-    // isPartials,
+    isPartials,
     path,
     pathRegexp,
     label,
@@ -242,10 +250,11 @@ const TabItem: React.FC<TabItemProps> = (props) => {
   const [isActiveTab, setIsActiveTab] = useState(false);
 
   useEffect(() => {
-    const pathname = Array.isArray(router.query.pathname) ? router.query.pathname[0] : router.query.pathname || router.asPath;
+    const pathname = Array.isArray(router.query.pathname)
+      ? router.query.pathname[0]
+      : router.query.pathname || router.asPath;
     setIsActiveTab(pathRegexp.test(pathname));
   }, [pathRegexp, router]);
-
   return (
     <TabItemWrapper
       css={
@@ -273,7 +282,10 @@ const TabItem: React.FC<TabItemProps> = (props) => {
           </StyledAnchor>
         </Link>
       ) : (
-        <StyledAnchor href={path} aria-label={label}>
+        <StyledAnchor
+          href={isPartials ? `${process.env.NEXT_PUBLIC_ACCOUNT_HOST}${path}` : path}
+          aria-label={label}
+        >
           <TabButton>
             {isActiveTab ? activeIcon : normalIcon}
             {addOn}
@@ -328,7 +340,9 @@ export const MainTab: React.FC<MainTabProps> = (props) => {
           normalIcon={<Home css={iconStyle} />}
           label={labels.mainTab.home}
           path="/"
-          pathRegexp={/^\/(romance|romance-serial|fantasy|fantasy-serial|bl|bl-serial|comics)?\/?$/}
+          pathRegexp={
+            /^\/(romance|romance-serial|fantasy|fantasy-serial|bl|bl-serial|comics)?\/?$/
+          }
         />
         <TabItem
           isPartials={isPartials}
@@ -337,9 +351,7 @@ export const MainTab: React.FC<MainTabProps> = (props) => {
           label={labels.mainTab.notification}
           path="/notification"
           pathRegexp={/^\/notification\/?$/g}
-          addOn={hasNotification && (
-            <NotificationAddOn />
-          )}
+          addOn={hasNotification && <NotificationAddOn />}
         />
         <TabItem
           isPartials={isPartials}
@@ -352,9 +364,7 @@ export const MainTab: React.FC<MainTabProps> = (props) => {
             cartCount > 0 && (
               <CartAddOnWrapper>
                 <CartAddOnBackground>
-                  <CartAddOnCount>
-                    {cartCount}
-                  </CartAddOnCount>
+                  <CartAddOnCount>{cartCount}</CartAddOnCount>
                 </CartAddOnBackground>
               </CartAddOnWrapper>
             )

--- a/src/tests/components/Search/InstantSearch.spec.tsx
+++ b/src/tests/components/Search/InstantSearch.spec.tsx
@@ -22,12 +22,12 @@ import fixtureABC from './abc.fixture.json';
 afterEach(cleanup);
 
 // axiosMock.get.mockResolvedValue();
-const renderComponent = async () => {
+const renderComponent = async (isPartials) => {
   let result: RenderResult;
   await act(async () => {
     result = render(
       <ThemeProvider theme={defaultTheme}>
-        <InstantSearch searchKeyword={''} />
+        <InstantSearch searchKeyword={''} isPartials={isPartials}/>
       </ThemeProvider>,
     );
   });
@@ -36,7 +36,7 @@ const renderComponent = async () => {
 
 describe('test instant search', () => {
   it('should be render input', async () => {
-    const { container } = await renderComponent();
+    const { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     expect(inputNode).not.toBe(null);
   });
@@ -46,7 +46,7 @@ describe('test instant search', () => {
       localStorageKeys.instantSearchHistory,
       JSON.stringify(['history_1', 'history_2']),
     );
-    const { container } = await renderComponent();
+    const { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     await act(async () => {
       fireEvent.focus(inputNode, {});
@@ -64,7 +64,7 @@ describe('test instant search', () => {
       localStorageKeys.instantSearchHistory,
       JSON.stringify(['history_1', 'history_2']),
     );
-    const { container } = await renderComponent();
+    const { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     await act(async () => {
       fireEvent.click(inputNode, {});
@@ -108,7 +108,7 @@ describe('test instant search', () => {
       localStorageKeys.instantSearchHistory,
       'maybe error be with you',
     );
-    const { container } = await renderComponent();
+    const { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     await act(async () => {
       fireEvent.click(inputNode, {});
@@ -124,7 +124,7 @@ describe('test instant search', () => {
         data: fixtureABC,
       };
     });
-    let { container } = await renderComponent();
+    let { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     await act(async () => {
       fireEvent.focus(inputNode);
@@ -139,7 +139,7 @@ describe('test instant search', () => {
 
   it('should not be render search result', async () => {
     jest.useFakeTimers();
-    const { container } = await renderComponent();
+    const { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     await act(async () => {
       fireEvent.change(inputNode, { target: { value: '가나' } });
@@ -150,7 +150,7 @@ describe('test instant search', () => {
   });
 
   it('can be add search history', async () => {
-    const { container } = await renderComponent();
+    const { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     const searchForm = container.getElementsByTagName('form');
     expect(searchForm).not.toBe(null);
@@ -173,7 +173,7 @@ describe('test instant search', () => {
       localStorageKeys.instantSearchHistory,
       JSON.stringify(['history_1']),
     );
-    const { container } = await renderComponent();
+    const { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     await act(async () => {
       fireEvent.focus(inputNode, {});
@@ -195,7 +195,7 @@ describe('test instant search', () => {
       localStorageKeys.instantSearchHistory,
       JSON.stringify(['history_1']),
     );
-    const { container } = await renderComponent();
+    const { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     await act(async () => {
       fireEvent.focus(inputNode, {});
@@ -229,7 +229,7 @@ describe('test instant search', () => {
       localStorageKeys.instantSearchHistory,
       JSON.stringify(['history_1', 'history_2']),
     );
-    const { container } = await renderComponent();
+    const { container } = await renderComponent(false);
     const inputNode = getByPlaceholderText(container, labels.searchPlaceHolder);
     await act(async () => {
       fireEvent.focus(inputNode, {});


### PR DESCRIPTION
### 관련 태스크

https://app.asana.com/0/947013990327604/1165942484748508
https://app.asana.com/0/36119352333069/1165739253132705
https://app.asana.com/0/36119352333069/1165739253132707

내 기기 관리 URL 이 https://account.ridibooks.com/devices 인데 
상대 경로로 달려있는 `<a/>` href 값이 기존에 개발 편의성을 위해 상대 경로로 달려 있었음 
이를 `isPartials` 값으로 분기하여 
`.env` 의 환경 값의 절대 경로 값이 들어가도록 수정
