### PR TITLE
탑 배너 첫 렌더 시 여백 적용 안 되는 문제 수정

### DIFF
--- a/src/components/Carousel/BigBannerCarousel.tsx
+++ b/src/components/Carousel/BigBannerCarousel.tsx
@@ -39,8 +39,8 @@ const CarouselList = styled.ul<{ slideMargin: number }>`
   flex-wrap: nowrap;
   align-items: center;
 
-  > li + li {
-    margin-left: ${(props) => props.slideMargin}px;
+  > li {
+    margin: 0 ${(props) => props.slideMargin / 2}px;
   }
 `;
 


### PR DESCRIPTION
`li` 다음에 `style`일 수 있었네요