### PR TITLE
데스크탑에서 책 목록 첫 렌더가 화면 너비 전체를 차지하던 문제 수정

### DIFF
--- a/src/components/RecommendedBook/RecommendedBook.tsx
+++ b/src/components/RecommendedBook/RecommendedBook.tsx
@@ -21,7 +21,7 @@ const SectionTitle = styled.h2`
   padding-left: 25px;
   padding-right: 8px;
 
-  font-size: 21px;
+  font-size: 19px;
   font-weight: normal;
 
   @media (max-width: ${BreakPoint.LG}px) {

--- a/src/components/RecommendedBook/RecommendedBookCarousel.tsx
+++ b/src/components/RecommendedBook/RecommendedBookCarousel.tsx
@@ -26,7 +26,7 @@ const CarouselWrapper = styled.div`
   width: 1005px;
   margin: 0 auto;
   position: relative;
-  margin-top: 6px;
+  margin-top: 20px;
 `;
 
 const bookWidthStyle = css`width: 140px;`;

--- a/src/components/RecommendedBook/RecommendedBookList.tsx
+++ b/src/components/RecommendedBook/RecommendedBookList.tsx
@@ -38,6 +38,14 @@ interface ListItemProps {
   genre: string;
 }
 
+const bookWidthStyle = css`
+  width: 100px;
+
+  @media (min-width: 1000px) {
+    width: 140px;
+  }
+`;
+
 const ListItem = React.memo((props: ListItemProps) => {
   const {
     book, index, type, theme, slug, genre,
@@ -53,7 +61,7 @@ const ListItem = React.memo((props: ListItemProps) => {
               margin-right: 20px;
             }
             @media (min-width: 1000px) {
-              margin-right: inherit !important;
+              margin-right: 22px;
             }
           `
           : css`
@@ -72,7 +80,7 @@ const ListItem = React.memo((props: ListItemProps) => {
           <ThumbnailRenderer
             className={slug}
             order={index}
-            css={css`width: 100px;`}
+            css={bookWidthStyle}
             sizes="100px"
             slug={slug}
             book={{ b_id: book.b_id, detail: book.detail }}
@@ -168,7 +176,8 @@ const RecommendedBookList: React.FC<RecommendedBookListProps> = React.memo((prop
     <div
       css={css`
         position: relative;
-        margin-top: 6px;
+        margin: 6px auto 0;
+        max-width: 1000px;
       `}
     >
       <ScrollContainer>
@@ -178,9 +187,17 @@ const RecommendedBookList: React.FC<RecommendedBookListProps> = React.memo((prop
             type === DisplayType.TodayRecommendation
               ? css`
                   padding-left: 35px;
+
+                  @media (min-width: 1000px) {
+                    padding-left: 25px;
+                  }
                 `
               : css`
                   padding-left: 13px;
+
+                  @media (min-width: 1000px) {
+                    padding-left: 25px;
+                  }
                 `,
           ]}
         >


### PR DESCRIPTION
UI의 떨림을 해결합니다.

스타일 조정도 조금 했습니다.