### PR TITLE
셀렉트 도서를 확인하지 못하는 문제 수정

### DIFF
--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -88,10 +88,11 @@ export const Home: NextPage<HomeProps> = (props) => {
       fetchHomeSections(props.genre, {}, {
         cancelToken: source.token,
       }).then((result) => {
-        setBranches(result.branches);
-        const bIds = keyToArray(result.branches, 'b_id');
+        const { branches: data = [] } = result;
+        setBranches(data);
+        const bIds = keyToArray(data, 'b_id');
         dispatch({ type: booksActions.insertBookIds.type, payload: bIds });
-        const categoryIds = keyToArray(result.branches, 'category_id');
+        const categoryIds = keyToArray(data, 'category_id');
         dispatch({
           type: categoryActions.insertCategoryIds.type,
           payload: categoryIds,

--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -78,7 +78,7 @@ export const Home: NextPage<HomeProps> = (props) => {
 
   const { genre = 'general' } = props;
   const previousGenre = usePrevious(genre);
-  const [branches, setBranches] = useState(props.branches);
+  const [branches, setBranches] = useState(props.branches || []);
 
   useEffect(() => {
     const source = CancelToken.source();
@@ -96,15 +96,20 @@ export const Home: NextPage<HomeProps> = (props) => {
           type: categoryActions.insertCategoryIds.type,
           payload: categoryIds,
         });
-        const selectBIds = keyToArray(
-          result.branches.filter((section) => section.extra.use_select_api),
-          'b_id',
-        );
-        dispatch({ type: booksActions.checkSelectBook.type, payload: selectBIds });
       });
     }
     return source.cancel;
   }, [genre, dispatch]);
+
+  useEffect(() => {
+    if (branches?.length > 0) {
+      const selectBIds = keyToArray(
+        branches.filter((section) => section.extra.use_select_api),
+        'b_id',
+      );
+      dispatch({ type: booksActions.checkSelectBook.type, payload: selectBIds });
+    }
+  }, [branches]);
 
   const [tracker] = useEventTracker();
   const setPageView = useCallback(() => {
@@ -167,6 +172,7 @@ Home.getInitialProps = async (ctx: ConnectedInitializeProps) => {
           type: categoryActions.insertCategoryIds.type,
           payload: categoryIds,
         });
+
         return {
           genre: genre.toString(),
           store,

--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -103,13 +103,11 @@ export const Home: NextPage<HomeProps> = (props) => {
   }, [genre, dispatch]);
 
   useEffect(() => {
-    if (branches?.length > 0) {
-      const selectBIds = keyToArray(
-        branches.filter((section) => section.extra.use_select_api),
-        'b_id',
-      );
-      dispatch({ type: booksActions.checkSelectBook.type, payload: selectBIds });
-    }
+    const selectBIds = keyToArray(
+      branches.filter((section) => section.extra.use_select_api),
+      'b_id',
+    );
+    dispatch({ type: booksActions.checkSelectBook.type, payload: selectBIds });
   }, [branches]);
 
   const [tracker] = useEventTracker();


### PR DESCRIPTION
현재 `books.ridi.io` 일반장르에서 `마션` 과 `나의 한국현대사` 가 리디셀렉트 도서로 표시되지 않고 있습니다.
`useEffect` 분리해서 다음 branches 를 바라본 후 요청하도록 수정했습니다.
  