### PR TITLE
다른 장르에서 일반 장르로 이동할 때 리로드하는 현상 수정

### DIFF
--- a/src/components/GNB/HomeLink.tsx
+++ b/src/components/GNB/HomeLink.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect, useContext } from 'react';
+import Link from 'next/link';
+import * as Cookies from 'js-cookie';
+
+import { GNBContext } from 'src/components/GNB';
+import cookieKeys from 'src/constants/cookies';
+
+interface Props {
+  passHref?: boolean;
+  isPartials: boolean;
+}
+
+const legacyCookieMap = {
+  comic: 'comics',
+  romance_serial: 'romance-serial',
+  fantasy_serial: 'fantasy-serial',
+  bl_serial: 'bl-serial',
+};
+
+const HomeLink: React.FC<Props> = (props) => {
+  const {
+    passHref = false,
+    isPartials,
+    children,
+  } = props;
+
+  const { origin } = useContext(GNBContext);
+  const [genre, setGenre] = useState('');
+
+  useEffect(() => {
+    const cookie = Cookies.get(cookieKeys.main_genre);
+    setGenre(legacyCookieMap[cookie] ?? cookie);
+  });
+
+  if (process.env.IS_PRODUCTION) {
+    return React.cloneElement(
+      children as React.ReactElement,
+      { href: `${origin}/` },
+    );
+  }
+  return (
+    <Link
+      href={{ pathname: '/[genre]', query: { genre: genre || 'general' } }}
+      as={`/${genre}`}
+      passHref={passHref}
+    >
+      {props.children}
+    </Link>
+  );
+};
+
+export default HomeLink;

--- a/src/components/GNB/HomeLink.tsx
+++ b/src/components/GNB/HomeLink.tsx
@@ -7,7 +7,6 @@ import cookieKeys from 'src/constants/cookies';
 
 interface Props {
   passHref?: boolean;
-  isPartials: boolean;
 }
 
 const legacyCookieMap = {
@@ -20,7 +19,6 @@ const legacyCookieMap = {
 const HomeLink: React.FC<Props> = (props) => {
   const {
     passHref = false,
-    isPartials,
     children,
   } = props;
 

--- a/src/components/GNB/HomeLink.tsx
+++ b/src/components/GNB/HomeLink.tsx
@@ -28,7 +28,7 @@ const HomeLink: React.FC<Props> = (props) => {
   useEffect(() => {
     const cookie = Cookies.get(cookieKeys.main_genre);
     setGenre(legacyCookieMap[cookie] ?? cookie);
-  });
+  }, []);
 
   if (process.env.IS_PRODUCTION) {
     return React.cloneElement(

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -402,7 +402,7 @@ export const GNB: React.FC<GNBProps> = React.memo((props: GNBProps) => {
               />
             </div>
           </Navigation>
-          <MainTab isPartials={props.isPartials} loggedUserInfo={loggedUser} />
+          <MainTab loggedUserInfo={loggedUser} />
         </Header>
       </GNBContext.Provider>
     </GNBWrapper>

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -14,6 +14,7 @@ import { RootState } from 'src/store/config';
 import { AccountState } from 'src/services/accounts/reducer';
 import { LoggedUser } from 'src/types/account';
 import { useRouter } from 'next/router';
+import HomeLink from 'src/components/GNB/HomeLink';
 import DoublePointIcon from 'src/svgs/DoublePoint.svg';
 import CashIcon from 'src/svgs/Cash.svg';
 import pRetry from 'p-retry';
@@ -364,17 +365,18 @@ export const GNB: React.FC<GNBProps> = React.memo((props: GNBProps) => {
             <div css={logoAndSearchBox}>
               <LogoWrapper>
                 <li>
-                  <a
-                    href={isPartials ? `${process.env.NEXT_STATIC_ACCOUNT_HOST}/` : '/'}
-                    aria-label="리디북스 홈으로 이동"
-                    css={css`
-                      display: flex;
-                      align-items: center;
-                    `}
-                  >
-                    <RidiLogo css={ridiLogo} />
-                    <span className="a11y">RIDIBOOKS</span>
-                  </a>
+                  <HomeLink passHref>
+                    <a
+                      aria-label="리디북스 홈으로 이동"
+                      css={css`
+                        display: flex;
+                        align-items: center;
+                      `}
+                    >
+                      <RidiLogo css={ridiLogo} />
+                      <span className="a11y">RIDIBOOKS</span>
+                    </a>
+                  </HomeLink>
                 </li>
                 <li>
                   <a

--- a/src/components/Tabs/GenreTab.tsx
+++ b/src/components/Tabs/GenreTab.tsx
@@ -5,7 +5,8 @@ import GNBCategory from 'src/svgs/GNB_Category.svg';
 import { css } from '@emotion/core';
 import { clearOutline } from 'src/styles';
 import { orBelow } from 'src/utils/mediaQuery';
-import { useRouter } from 'next/router';
+import Router, { useRouter } from 'next/router';
+import cookieKeys, { DEFAULT_COOKIE_EXPIRES } from 'src/constants/cookies';
 import * as Cookies from 'js-cookie';
 
 import { safeJSONParse } from 'src/utils/common';
@@ -246,8 +247,15 @@ const TabItem: React.FC<TabItemProps> = (props) => {
           href={href === '/' ? { pathname: '/[genre]', query: { genre: 'general' } } : '/[genre]'}
           as={href}
         >
-          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-          <a aria-label={label}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+          <a
+            aria-label={label}
+            onClick={() => {
+              if (href === '/' && cookieGenre) {
+                Cookies.set('main_genre', '', { sameSite: 'lax' });
+              }
+            }}
+          >
             {isActivePath ? <ActiveText>{label}</ActiveText> : <span>{label}</span>}
           </a>
         </Link>
@@ -366,6 +374,29 @@ const GenreTab: React.FC<GenreTabProps> = React.memo((props) => {
       {props.isPartials && <GenreTabDivider />}
     </>
   );
+});
+
+const legacyCookieMap = {
+  general: '',
+  comics: 'comic',
+  'romance-serial': 'romance_serial',
+  'fantasy-serial': 'fantasy_serial',
+  'bl-serial': 'bl_serial',
+};
+
+Router.events.on('routeChangeComplete', () => {
+  const { pathname, query } = Router.router;
+  if (pathname === '/[genre]') {
+    const genre = query.genre?.toString();
+    Cookies.set(
+      cookieKeys.main_genre,
+      legacyCookieMap[genre] ?? genre,
+      {
+        expires: DEFAULT_COOKIE_EXPIRES,
+        sameSite: 'lax',
+      },
+    );
+  }
 });
 
 export default GenreTab;

--- a/src/components/Tabs/GenreTab.tsx
+++ b/src/components/Tabs/GenreTab.tsx
@@ -195,6 +195,29 @@ const GenreTabDivider = styled.hr`
   background: #e6e8eb;
 `;
 
+const legacyCookieMap = {
+  general: '',
+  comics: 'comic',
+  'romance-serial': 'romance_serial',
+  'fantasy-serial': 'fantasy_serial',
+  'bl-serial': 'bl_serial',
+};
+
+const routeChangeCompleteHandler = () => {
+  const { pathname, query } = Router.router;
+  if (pathname === '/[genre]') {
+    const genre = query.genre?.toString();
+    Cookies.set(
+      cookieKeys.main_genre,
+      legacyCookieMap[genre] ?? genre,
+      {
+        expires: DEFAULT_COOKIE_EXPIRES,
+        sameSite: 'lax',
+      },
+    );
+  }
+};
+
 interface TabItemProps {
   label: string;
   activePath: RegExp;
@@ -306,6 +329,14 @@ const GenreTab: React.FC<GenreTabProps> = React.memo((props) => {
       localStorage.setItem('latest_sub_service', JSON.stringify(updatedSubService));
     }
   }, [router.asPath]);
+
+  useEffect(() => {
+    Router.events.on('routeChangeComplete', routeChangeCompleteHandler);
+    return () => {
+      Router.events.off('routeChangeComplete', routeChangeCompleteHandler);
+    };
+  }, []);
+
   return (
     <>
       <GenreTabWrapper>
@@ -374,29 +405,6 @@ const GenreTab: React.FC<GenreTabProps> = React.memo((props) => {
       {props.isPartials && <GenreTabDivider />}
     </>
   );
-});
-
-const legacyCookieMap = {
-  general: '',
-  comics: 'comic',
-  'romance-serial': 'romance_serial',
-  'fantasy-serial': 'fantasy_serial',
-  'bl-serial': 'bl_serial',
-};
-
-Router.events.on('routeChangeComplete', () => {
-  const { pathname, query } = Router.router;
-  if (pathname === '/[genre]') {
-    const genre = query.genre?.toString();
-    Cookies.set(
-      cookieKeys.main_genre,
-      legacyCookieMap[genre] ?? genre,
-      {
-        expires: DEFAULT_COOKIE_EXPIRES,
-        sameSite: 'lax',
-      },
-    );
-  }
 });
 
 export default GenreTab;

--- a/src/components/Tabs/GenreTab.tsx
+++ b/src/components/Tabs/GenreTab.tsx
@@ -242,7 +242,10 @@ const TabItem: React.FC<TabItemProps> = (props) => {
           {isActivePath ? <ActiveText>{label}</ActiveText> : <span>{label}</span>}
         </a>
       ) : (
-        <Link href={href === '/' ? '/' : '/[genre]'} as={href}>
+        <Link
+          href={href === '/' ? { pathname: '/[genre]', query: { genre: 'general' } } : '/[genre]'}
+          as={href}
+        >
           {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
           <a aria-label={label}>
             {isActivePath ? <ActiveText>{label}</ActiveText> : <span>{label}</span>}

--- a/src/components/Tabs/MainTab.tsx
+++ b/src/components/Tabs/MainTab.tsx
@@ -207,12 +207,10 @@ const CartAddOnCount = styled.span`
 
 
 interface MainTabProps {
-  isPartials: boolean;
   loggedUserInfo: null | LoggedUser;
 }
 
 interface TabItemProps {
-  isPartials: boolean;
   replace?: boolean;
   shallow?: boolean;
   path: string;
@@ -230,7 +228,6 @@ interface TabItemProps {
 const TabItem: React.FC<TabItemProps> = (props) => {
   const {
     path,
-    isPartials,
     pathRegexp,
     label,
     activeIcon,
@@ -280,7 +277,7 @@ const TabItem: React.FC<TabItemProps> = (props) => {
           <TabButtonWithLine />
         </StyledAnchor>
       ) : path === '/' ? (
-        <HomeLink isPartials={isPartials} passHref>
+        <HomeLink passHref>
           <StyledAnchor aria-label={label}>
             <TabButtonWithLine />
           </StyledAnchor>
@@ -308,7 +305,7 @@ const genreValueReplace = (visitedGenre: string) => {
 };
 
 export const MainTab: React.FC<MainTabProps> = (props) => {
-  const { isPartials, loggedUserInfo } = props;
+  const { loggedUserInfo } = props;
   const { hasNotification } = useSelector((store: RootState) => store.notifications);
   const router = useRouter();
   const [, setHomeURL] = useState('/');
@@ -333,7 +330,6 @@ export const MainTab: React.FC<MainTabProps> = (props) => {
     <>
       <Tabs>
         <TabItem
-          isPartials={isPartials}
           activeIcon={<HomeSolid css={iconStyle} />}
           normalIcon={<Home css={iconStyle} />}
           label={labels.mainTab.home}
@@ -341,7 +337,6 @@ export const MainTab: React.FC<MainTabProps> = (props) => {
           pathRegexp={/^\/(romance|romance-serial|fantasy|fantasy-serial|bl|bl-serial|comics)?\/?$/}
         />
         <TabItem
-          isPartials={isPartials}
           activeIcon={<Notification_solid css={iconStyle} />}
           normalIcon={<Notification_regular css={iconStyle} />}
           label={labels.mainTab.notification}
@@ -352,7 +347,6 @@ export const MainTab: React.FC<MainTabProps> = (props) => {
           )}
         />
         <TabItem
-          isPartials={isPartials}
           activeIcon={<Cart_solid css={iconStyle} />}
           normalIcon={<Cart_regular css={iconStyle} />}
           label={labels.mainTab.cart}
@@ -371,7 +365,6 @@ export const MainTab: React.FC<MainTabProps> = (props) => {
           }
         />
         <TabItem
-          isPartials={isPartials}
           activeIcon={<MyRIDI_solid css={iconStyle} />}
           normalIcon={<MyRIDI_regular css={iconStyle} />}
           label={labels.mainTab.myRidi}

--- a/src/components/Tabs/MainTab.tsx
+++ b/src/components/Tabs/MainTab.tsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 import { a11y } from 'src/styles';
 import * as labels from 'src/labels/menus.json';
 import * as Cookies from 'js-cookie';
+import HomeLink from 'src/components/GNB/HomeLink';
 import Home from 'src/svgs/Home.svg';
 import HomeSolid from 'src/svgs/Home_solid.svg';
 import Notification_solid from 'src/svgs/Notification_solid.svg';
@@ -220,7 +221,6 @@ interface TabItemProps {
   label: string;
   pathRegexp: RegExp;
   addOn?: React.ReactNode;
-  isSPA?: boolean;
 }
 
 // Todo
@@ -230,12 +230,12 @@ interface TabItemProps {
 const TabItem: React.FC<TabItemProps> = (props) => {
   const {
     path,
+    isPartials,
     pathRegexp,
     label,
     activeIcon,
     normalIcon,
     addOn,
-    isSPA = false,
   } = props;
 
   const router = useRouter();
@@ -247,6 +247,17 @@ const TabItem: React.FC<TabItemProps> = (props) => {
     const pathname = Array.isArray(router.query.pathname) ? router.query.pathname[0] : router.query.pathname || router.asPath;
     setIsActiveTab(pathRegexp.test(pathname));
   }, [pathRegexp, router]);
+
+  const TabButtonWithLine = () => (
+    <>
+      <TabButton>
+        {isActiveTab ? activeIcon : normalIcon}
+        {addOn}
+        <span css={labelStyle}>{label}</span>
+      </TabButton>
+      <BottomLine css={isActiveTab && currentTab} />
+    </>
+  );
 
   return (
     <TabItemWrapper
@@ -263,26 +274,23 @@ const TabItem: React.FC<TabItemProps> = (props) => {
           : ''
       }
     >
-      {isSPA ? (
-        <Link href={path}>
+      {/* eslint-disable-next-line no-nested-ternary */}
+      {process.env.IS_PRODUCTION ? (
+        <StyledAnchor href={`${origin}${path}`} aria-label={label}>
+          <TabButtonWithLine />
+        </StyledAnchor>
+      ) : path === '/' ? (
+        <HomeLink isPartials={isPartials} passHref>
           <StyledAnchor aria-label={label}>
-            <TabButton>
-              {isActiveTab ? activeIcon : normalIcon}
-              {addOn}
-              <span css={labelStyle}>{label}</span>
-            </TabButton>
-            <BottomLine css={isActiveTab ? currentTab : css``} />
+            <TabButtonWithLine />
+          </StyledAnchor>
+        </HomeLink>
+      ) : (
+        <Link href={path} passHref>
+          <StyledAnchor aria-label={label}>
+            <TabButtonWithLine />
           </StyledAnchor>
         </Link>
-      ) : (
-        <StyledAnchor href={`${origin}${path}`} aria-label={label}>
-          <TabButton>
-            {isActiveTab ? activeIcon : normalIcon}
-            {addOn}
-            <span css={labelStyle}>{label}</span>
-          </TabButton>
-          <BottomLine css={isActiveTab ? currentTab : css``} />
-        </StyledAnchor>
       )}
     </TabItemWrapper>
   );

--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -4,8 +4,6 @@ import React, {
 import Head from 'next/head';
 import { ConnectedInitializeProps } from 'src/types/common';
 import { GenreTab } from 'src/components/Tabs';
-import cookieKeys, { DEFAULT_COOKIE_EXPIRES } from 'src/constants/cookies';
-import * as Cookies from 'js-cookie';
 import titleGenerator from 'src/utils/titleGenerator';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -43,25 +41,6 @@ const fetchHomeSections = async (genre = 'general', params = {}, options = {}) =
     },
   );
   return result.data;
-};
-
-// legacy genre 로 쿠키 값 설정
-const setCookie = (genre: string) => {
-  let convertedLegacyGenre = '';
-  if (genre === 'comics') {
-    convertedLegacyGenre = 'comic';
-  } else if (genre.includes('-')) {
-    convertedLegacyGenre = genre.replace('-', '_');
-  } else if (genre === 'general') {
-    convertedLegacyGenre = '';
-  } else {
-    convertedLegacyGenre = genre;
-  }
-
-  Cookies.set(cookieKeys.main_genre, convertedLegacyGenre, {
-    expires: DEFAULT_COOKIE_EXPIRES,
-    sameSite: 'lax',
-  });
 };
 
 const usePrevious = <T extends {}>(value: T) => {
@@ -122,9 +101,8 @@ export const Home: NextPage<HomeProps> = (props) => {
   }, [tracker]);
 
   useEffect(() => {
-    setCookie(props.genre);
     setPageView();
-  }, [props.genre, loggedUser, setPageView]);
+  }, [genre, loggedUser, setPageView]);
 
   return (
     <>

--- a/src/tests/components/Tabs/MainTab.spec.tsx
+++ b/src/tests/components/Tabs/MainTab.spec.tsx
@@ -15,7 +15,7 @@ const renderComponent = () =>
     <ThemeProvider theme={defaultTheme}>
       <RouterContext.Provider value={{ asPath: '' , query: { pathname: '/'}}}>
         <Provider store={store}>
-          <MainTab isPartials={false} />
+          <MainTab />
         </Provider>
       </RouterContext.Provider>
     </ThemeProvider>,


### PR DESCRIPTION
- 링크 이동 수정 - GenreTab `일반` 장르 링크, MainTab `홈` 링크, GNB 리디북스 로고
- 개발환경과 partial 페이지가 아닌 경우 메인 탭에서 Link 컴포넌트 사용