### PR TITLE
Fix/profile-live-step 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       - steps: << parameters.after-scripts >>
   profile-live:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:lts-browsers
     working_directory: ~/books-frontend
     parameters:
       url:


### PR DESCRIPTION
profile step 때 에러가 나는 거 같아 circleCI 를 조금 수정했습니다.
https://app.circleci.com/pipelines/github/ridi/books-frontend/770/workflows/b21a6210-2109-4561-bfdc-d05102c26a76/jobs/619

참고:
https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-on-circleci