### PR TITLE
USE_CSR=true인 경우 마지막 이용 장르로 전환

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -74,6 +74,7 @@ const nextConfig = {
     );
 
     config.plugins.push(new webpack.DefinePlugin({
+      'process.env.USE_CSR': JSON.stringify(process.env.USE_CSR),
       'process.env.STAGE': JSON.stringify(process.env.STAGE),
       'process.env.BUILD_ID': JSON.stringify(buildId),
       'process.env.IS_SERVER': JSON.stringify(isServer),

--- a/src/components/GNB/HomeLink.tsx
+++ b/src/components/GNB/HomeLink.tsx
@@ -30,7 +30,7 @@ const HomeLink: React.FC<Props> = (props) => {
     setGenre(legacyCookieMap[cookie] ?? cookie);
   }, []);
 
-  if (process.env.IS_PRODUCTION) {
+  if (!process.env.USE_CSR) {
     return React.cloneElement(
       children as React.ReactElement,
       { href: `${origin}/` },

--- a/src/components/GNB/HomeLink.tsx
+++ b/src/components/GNB/HomeLink.tsx
@@ -9,7 +9,7 @@ interface Props {
   passHref?: boolean;
 }
 
-const legacyCookieMap = {
+export const legacyCookieMap = {
   comic: 'comics',
   romance_serial: 'romance-serial',
   fantasy_serial: 'fantasy-serial',

--- a/src/components/Tabs/GenreTab.tsx
+++ b/src/components/Tabs/GenreTab.tsx
@@ -253,7 +253,7 @@ const TabItem: React.FC<TabItemProps> = (props) => {
 
   return (
     <li css={isActivePath ? activeLabelCSS : genreLabelCSS}>
-      {process.env.IS_PRODUCTION ? (
+      {!process.env.USE_CSR ? (
         <a
           aria-label={label}
           href={href}

--- a/src/components/Tabs/GenreTab.tsx
+++ b/src/components/Tabs/GenreTab.tsx
@@ -332,6 +332,9 @@ const GenreTab: React.FC<GenreTabProps> = React.memo((props) => {
 
   useEffect(() => {
     Router.events.on('routeChangeComplete', routeChangeCompleteHandler);
+    if (process.env.USE_CSR && router.query.genre !== 'general') {
+      routeChangeCompleteHandler();
+    }
     return () => {
       Router.events.off('routeChangeComplete', routeChangeCompleteHandler);
     };

--- a/src/components/Tabs/MainTab.tsx
+++ b/src/components/Tabs/MainTab.tsx
@@ -272,7 +272,7 @@ const TabItem: React.FC<TabItemProps> = (props) => {
       }
     >
       {/* eslint-disable-next-line no-nested-ternary */}
-      {process.env.IS_PRODUCTION ? (
+      {!process.env.USE_CSR ? (
         <StyledAnchor href={`${origin}${path}`} aria-label={label}>
           <TabButtonWithLine />
         </StyledAnchor>

--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -6,6 +6,7 @@ import { ConnectedInitializeProps } from 'src/types/common';
 import { GenreTab } from 'src/components/Tabs';
 import titleGenerator from 'src/utils/titleGenerator';
 import { useDispatch, useSelector } from 'react-redux';
+import { useRouter } from 'next/router';
 
 import { Page, Section } from 'src/types/sections';
 import { HomeSectionRenderer } from 'src/components/Section/HomeSectionRenderer';
@@ -19,6 +20,10 @@ import { NextPage } from 'next';
 import { useEventTracker } from 'src/hooks/useEventTracker';
 import { RootState } from 'src/store/config';
 import { css } from '@emotion/core';
+
+import * as Cookies from 'js-cookie';
+import cookieKeys from 'src/constants/cookies';
+import { legacyCookieMap } from 'src/components/GNB/HomeLink';
 
 const { captureException } = sentry();
 
@@ -54,10 +59,18 @@ const usePrevious = <T extends {}>(value: T) => {
 export const Home: NextPage<HomeProps> = (props) => {
   const { loggedUser } = useSelector((state: RootState) => state.account);
   const dispatch = useDispatch();
+  const route = useRouter();
 
   const { genre = 'general' } = props;
   const previousGenre = usePrevious(genre);
   const [branches, setBranches] = useState(props.branches || []);
+
+  useEffect(() => {
+    const cookie = Cookies.get(cookieKeys.main_genre);
+    if (process.env.USE_CSR && genre === 'general' && cookie) {
+      route.replace('/[genre]', `/${legacyCookieMap[cookie] ?? cookie}`);
+    }
+  }, []);
 
   useEffect(() => {
     const source = CancelToken.source();


### PR DESCRIPTION
https://github.com/ridi/books-frontend/pull/128 에 이어서 `IS_PRODUCTION` 대신 `USE_CSR` 환경변수를 사용하도록 변경하고, `/` 로 접근 시 마지막 이용 장르 쿠키가 있으면 전환되도록 수정했습니다.