### PR TITLE
Circle CI workspace 보관 기간이 짧아서 롤백을 하지 못하는 문제 수정

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,13 @@ jobs:
       STAGE: << parameters.stage >>
       ASSET_PREFIX: << parameters.assetPrefix >>
     steps:
+      - run:
+          command:
+            yarn serverless deploy list -s << parameters.stage >> | awk '/Timestamp/ {print $NF}' | tail -n 1 > .lastdeploytimestamp
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .lastdeploytimestamp
       - checkout
       - attach_workspace:
           at: .
@@ -124,13 +131,6 @@ jobs:
       - install
       - run:
           command: yarn deploy -s << parameters.stage >>
-      - run:
-          command:
-            yarn serverless deploy list -s << parameters.stage >> | awk '/Timestamp/ {print $NF}' | tail -n 1 > .deploytimestamp
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .deploytimestamp
       - steps: << parameters.after-scripts >>
   profile-live:
     docker:
@@ -166,7 +166,7 @@ jobs:
             curl -o- -L https://slss.io/install | bash
             export PATH="$HOME/.serverless/bin:$PATH"
       - run:
-          command: serverless rollback -t `cat .deploytimestamp`
+          command: serverless rollback -t `cat .lastdeploytimestamp`
       - steps: << parameters.after-scripts >>
 workflows:
   version: 2


### PR DESCRIPTION
롤백을 위한 릴리즈 timestamp를 배포 후 저장하지 않고, 배포 전에 이전 릴리즈의 timestamp를 기록해두고 배포합니다.

**롤백을 하려면, 이전 workflow의 rollback 을 실행하지 않고, 마지막으로 배포된 workflow의 rollback 을 실행합니다.**


---
예) release/B 브랜치 배포 후 release/A 으로 롤백해야하는 경우

이전: release/A 브랜치 workflow의 rollback job approve
- workflow 실행 후 15일이 지나면 저장된 timestamp 가 사라져 롤백 불가능

이후: release/B 브랜치 workflow의 rollback job approve