### PR TITLE
이전 릴리즈 timestamp 기록을 yarn install 이후로 이동 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,13 +111,6 @@ jobs:
       STAGE: << parameters.stage >>
       ASSET_PREFIX: << parameters.assetPrefix >>
     steps:
-      - run:
-          command:
-            yarn serverless deploy list -s << parameters.stage >> | awk '/Timestamp/ {print $NF}' | tail -n 1 > .lastdeploytimestamp
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .lastdeploytimestamp
       - checkout
       - attach_workspace:
           at: .
@@ -129,6 +122,13 @@ jobs:
           arguments: |
             --exclude "*.map"
       - install
+      - run:
+          command:
+            yarn serverless deploy list -s << parameters.stage >> | awk '/Timestamp/ {print $NF}' | tail -n 1 > .lastdeploytimestamp
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .lastdeploytimestamp
       - run:
           command: yarn deploy -s << parameters.stage >>
       - steps: << parameters.after-scripts >>


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/ridi/books-frontend/813/workflows/c7aec1f5-3222-4f21-84b7-547d97352db3/jobs/643
배포가 안되어 로그를 보니 
`Checkout, Deps install 을 하기 전`이라 아직 아무것도 없는 상태인 거 같습니다.

yarn deploy 하기 직전으로 step 을 옮깁니다.
