### PR TITLE
link-name audit 경고로 변경

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -61,7 +61,10 @@
         "works-offline": [
           "off",{}
         ],
-
+        "link-name": [
+          "warn",
+          {}
+        ],
         "service-worker": [
           "warn",{}
         ],


### PR DESCRIPTION
`/comics, /bl` 에서 link-name audit Error 가 2건 발생해서 Actions 다음 스텦으로 넘어가지 않아 LHCI-Server 에 리포팅이 안되고 있음

일단 `warn` 으로 변경 

https://web.dev/link-name/
