### PR TITLE
Rename: `NEXT_STATIC_SENTRY_DSN` -> `SENTRY_DSN`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -81,6 +81,7 @@ const nextConfig = {
     config.plugins.push(new webpack.DefinePlugin({
       'process.env.USE_CSR': JSON.stringify(process.env.USE_CSR),
       'process.env.STAGE': JSON.stringify(process.env.STAGE),
+      'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN),
       'process.env.BUILD_ID': JSON.stringify(buildId),
       'process.env.IS_SERVER': JSON.stringify(isServer),
       'process.env.IS_PRODUCTION': JSON.stringify(process.env.NODE_ENV === 'production'),

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -5,7 +5,7 @@ const { captureException, withScope, init } = Sentry;
 
 export default () => {
   const sentryOptions = {
-    dsn: process.env.NEXT_STATIC_SENTRY_DSN,
+    dsn: process.env.SENTRY_DSN,
     release: process.env.BUILD_ID,
     maxBreadcrumbs: 30,
     environment: process.env.STAGE,


### PR DESCRIPTION
`@sentry/webpack-plugin` 에서 SENTRY_DSN 환경 변수에 접근해서, 빌드 타임에서도 NEXT_STATIC prefix를 제거하고 DefinePlugin 으로 전달합니다.