### PR TITLE
mediaQuery CSS가 문자열을 받아 문자열을 반환하도록 함

### DIFF
--- a/src/components/Book/PortraitBook.tsx
+++ b/src/components/Book/PortraitBook.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
-import { between, BreakPoint, orBelow } from 'src/utils/mediaQuery';
-import { css } from '@emotion/core';
+import { BreakPoint, orBelow } from 'src/utils/mediaQuery';
 
 export const PortraitBook = styled.li`
   display: flex;
@@ -10,20 +9,12 @@ export const PortraitBook = styled.li`
   width: 140px;
 
   ${orBelow(
-    BreakPoint.MD,
-    css`
+    BreakPoint.LG,
+    `
       min-width: 100px;
       width: 100px;
     `,
   )}
-  ${between(
-    834,
-    999,
-    css`
-      min-width: 100px;
-      width: 100px;
-    `,
-  )};
 `;
 
 export const RecommendedPortraitBook = styled.li`
@@ -35,7 +26,7 @@ export const RecommendedPortraitBook = styled.li`
 
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       min-width: 100px;
       width: 100px;
     `,

--- a/src/components/BookMeta/BookMeta.tsx
+++ b/src/components/BookMeta/BookMeta.tsx
@@ -16,9 +16,7 @@ const BookTitle = styled.div`
   margin-bottom: 4.5px;
   ${orBelow(
     999,
-    css`
-      font-size: 14px;
-    `,
+    'font-size: 14px;',
   )}
 `;
 

--- a/src/components/BookSections/BookSectionContainer.tsx
+++ b/src/components/BookSections/BookSectionContainer.tsx
@@ -20,14 +20,14 @@ const titleCSS = css`
   ${between(
     BreakPoint.MD + 1,
     BreakPoint.LG,
-    css`
+    `
       padding-left: 20px;
       padding-right: 20px;
     `,
   )};
   ${orBelow(
     BreakPoint.MD,
-    css`
+    `
       padding-left: 16px;
       padding-right: 16px;
     `,

--- a/src/components/BookSections/RankingBook/RankingBookList.tsx
+++ b/src/components/BookSections/RankingBook/RankingBookList.tsx
@@ -36,7 +36,7 @@ const SectionWrapper = styled.section`
 
   ${orBelow(
     999,
-    css`
+    `
       padding-top: 16px;
       padding-bottom: 16px;
     `,
@@ -120,7 +120,7 @@ const List = styled.ul<{ type: 'big' | 'small' }>`
 
   ${greaterThanOrEqualTo(
     BreakPoint.MD + 1,
-    css`
+    `
       padding-left: 20px;
       padding-right: 20px;
     `,
@@ -128,7 +128,7 @@ const List = styled.ul<{ type: 'big' | 'small' }>`
 
   ${greaterThanOrEqualTo(
     BreakPoint.LG + 1,
-    css`
+    `
       padding-left: 24px;
       padding-right: 24px;
     `,

--- a/src/components/BookSections/SelectionBook/SelectionBook.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBook.tsx
@@ -37,7 +37,7 @@ const SectionWrapper = styled.section`
   padding-bottom: 24px;
   ${orBelow(
     999,
-    css`
+    `
       padding-top: 16px;
       padding-bottom: 16px;
     `,

--- a/src/components/BookSections/SelectionBook/SelectionBookCarousel.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookCarousel.tsx
@@ -104,7 +104,7 @@ const SelectionBookCarousel: React.FC<SelectionBookCarouselProps> = React.memo((
               ${arrowWrapperCSS};
               ${greaterThanOrEqualTo(
               BreakPoint.XL + 1,
-              css`left: -29px;`,
+              'left: -29px;',
             )};
               left: 5px;
               top: ${getArrowVerticalCenterPosition()};
@@ -119,7 +119,7 @@ const SelectionBookCarousel: React.FC<SelectionBookCarouselProps> = React.memo((
               ${arrowWrapperCSS};
               ${greaterThanOrEqualTo(
               BreakPoint.XL + 1,
-              css`right: -36px;`,
+              'right: -36px;',
             )};
               right: 5px;
               top: ${getArrowVerticalCenterPosition()};

--- a/src/components/BookSections/SelectionBook/SelectionBookList.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookList.tsx
@@ -17,7 +17,7 @@ export const listCSS = css`
   overflow-y: hidden;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       margin-left: -5px;
       //margin-right: 6px;
     `,
@@ -36,7 +36,7 @@ export const itemCSS = css`
 
   ${orBelow(
     BreakPoint.MD,
-    css`
+    `
       margin-right: 12px;
       :first-of-type {
         padding-left: 16px;
@@ -46,7 +46,7 @@ export const itemCSS = css`
   ${between(
     834,
     999,
-    css`
+    `
       margin-right: 20px;
     `,
   )};
@@ -64,7 +64,7 @@ export const loadingItemCSS = css`
 
   ${orBelow(
     BreakPoint.MD,
-    css`
+    `
       margin-right: 12px;
       :first-of-type {
         padding-left: 13px;
@@ -74,7 +74,7 @@ export const loadingItemCSS = css`
   ${between(
     834,
     999,
-    css`
+    `
       :first-of-type {
         padding-left: 17px;
       }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -23,9 +23,7 @@ const createCSS = (theme: RIDITheme, type: 'primary' | 'secondary') => css`
 
   ${orBelow(
     BreakPoint.LG,
-    css`
-      padding: 0 8px;
-    `,
+    'padding: 0 8px;',
   )};
   :hover {
     opacity: 0.7;

--- a/src/components/EventBanner/EventBanner.tsx
+++ b/src/components/EventBanner/EventBanner.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { css } from '@emotion/core';
 import { EventBannerList } from 'src/components/EventBanner';
 import { EventBanner as EventBannerItem } from 'src/types/sections';
 import { orBelow } from 'src/utils/mediaQuery';
@@ -12,9 +11,7 @@ const Section = styled.section`
   height: 100%;
   ${orBelow(
     999,
-    css`
-      padding: 16px 0;
-    `,
+    'padding: 16px 0;',
   )}
 `;
 

--- a/src/components/EventBanner/EventBannerItem.tsx
+++ b/src/components/EventBanner/EventBannerItem.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import {
   between, BreakPoint, greaterThanOrEqualTo, orBelow,
 } from 'src/utils/mediaQuery';
@@ -10,7 +9,7 @@ const EventBannerItem = styled.li`
 
   ${orBelow(
     BreakPoint.MD,
-    css`
+    `
       :not(:nth-of-type(2n)) {
         margin-right: 4px;
       }
@@ -21,7 +20,7 @@ const EventBannerItem = styled.li`
   ${between(
     BreakPoint.MD + 1,
     BreakPoint.LG,
-    css`
+    `
       :not(:last-of-type) {
         margin-right: 6px;
       }
@@ -30,7 +29,7 @@ const EventBannerItem = styled.li`
   )};
   ${greaterThanOrEqualTo(
     BreakPoint.LG + 1,
-    css`
+    `
       :not(:last-of-type) {
         margin-right: 8px;
       }

--- a/src/components/EventBanner/EventBannerList.tsx
+++ b/src/components/EventBanner/EventBannerList.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react';
 import { EventBannerItem } from 'src/components/EventBanner/index';
-import { css } from '@emotion/core';
 import { between, BreakPoint, orBelow } from 'src/utils/mediaQuery';
 import { EventBanner } from 'src/types/sections';
 import { useIntersectionObserver } from 'src/hooks/useIntersectionObserver';
@@ -15,14 +14,14 @@ const List = styled.ul`
   align-items: center;
   ${orBelow(
     BreakPoint.MD,
-    css`
+    `
       flex-wrap: wrap;
     `,
   )};
   ${between(
     BreakPoint.MD + 1,
     BreakPoint.LG,
-    css`
+    `
       padding-left: 20px;
       padding-right: 20px;
     `,

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -39,7 +39,7 @@ const FlexBox = styled.div`
   justify-content: unset;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       flex-direction: column;
       justify-content: flex-start;
       align-items: unset;
@@ -72,9 +72,7 @@ const contactListCSS = (theme: RIDITheme) => css`
 
   ${orBelow(
     BreakPoint.LG,
-    css`
-      margin-bottom: 28px;
-    `,
+    'margin-bottom: 28px;',
   )}
 `;
 
@@ -97,7 +95,7 @@ const FooterMenuWrapper = styled.ul`
   margin-bottom: 48px;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       margin-bottom: 24px;
       transition: all 0.3s;
       max-height: 230px;
@@ -124,9 +122,7 @@ const FooterMenuLabel = styled.span`
 const hiddenMenu = css`
   ${orBelow(
     BreakPoint.LG,
-    css`
-      display: none;
-    `,
+    'display: none;',
   )};
 `;
 
@@ -143,7 +139,7 @@ const InformationWrapper = styled.address`
   margin-bottom: 8px;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       flex-direction: column;
       margin-bottom: 16px;
     `,
@@ -166,7 +162,7 @@ const MiscWrapper = styled.div`
   flex-direction: row;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       flex-direction: column;
       align-items: flex-start;
       justify-content: center;
@@ -189,9 +185,7 @@ const Copyright = styled.p`
   margin-right: 24px;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      margin-bottom: 16px;
-    `,
+    'margin-bottom: 16px;',
   )};
 `;
 
@@ -393,9 +387,7 @@ const Footer: React.FC<{}> = () => (
                   transition: height 0.3s ease-in-out;
                   ${greaterThanOrEqualTo(
                   BreakPoint.LG + 1,
-                  css`
-                      display: none;
-                    `,
+                  'display: none;',
                 )};
                 `}
               >
@@ -528,9 +520,7 @@ const Footer: React.FC<{}> = () => (
             border-left: 1px solid ${colors.slateGray70};
             ${orBelow(
             BreakPoint.LG,
-            css`
-                display: none;
-              `,
+            'display: none;',
           )};
           `}
         />

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -38,9 +38,7 @@ const Navigation = styled.nav`
   flex-direction: column;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      padding: 9px 10px;
-    `,
+    'padding: 9px 10px;',
   )};
 `;
 
@@ -50,7 +48,7 @@ const LogoWrapper = styled.ul`
   flex: none;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       height: 30px;
       margin-right: 0;
     `,
@@ -76,7 +74,7 @@ const LogoWrapper = styled.ul`
 
       ${orBelow(
     BreakPoint.LG,
-    css`
+    `
           margin: 0 6px 0 5px;
           top: 7px;
           font-size: 12px;
@@ -101,7 +99,7 @@ const ridiLogo = (theme: RIDITheme) => css`
   }
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       width: 88px;
       height: 14px;
       :hover {
@@ -123,7 +121,7 @@ const ridiSelectLogo = (theme: RIDITheme) => css`
 
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       width: 73px;
       height: 12px;
     `,
@@ -140,7 +138,7 @@ const ButtonWrapper = styled.ul`
   order: 3;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       right: 10px;
       order: 2;
       position: absolute;
@@ -153,9 +151,7 @@ const ButtonWrapper = styled.ul`
 
       ${orBelow(
     BreakPoint.LG,
-    css`
-          margin-right: 3px;
-        `,
+    'margin-right: 3px;',
   )};
     }
   }
@@ -166,9 +162,7 @@ const logoAndSearchBox = css`
   flex-direction: row;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      flex-wrap: wrap;
-    `,
+    'flex-wrap: wrap;',
   )};
 `;
 
@@ -265,12 +259,7 @@ const GNBButtons: React.FC<GNBButtonsProps> = (props) => {
                     >
                       캐시
                       <span
-                        css={orBelow(
-                          330,
-                          css`
-                            display: none;
-                          `,
-                        )}
+                        css={orBelow(330, 'display: none;')}
                       >
                         충전
                       </span>

--- a/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
+++ b/src/components/KeywordFinder/HomeKeywordFinderSection.tsx
@@ -385,7 +385,7 @@ const Section = styled.section`
   padding-top: 24px;
   ${orBelow(
     999,
-    css`
+    `
       padding-bottom: 16px;
       padding-top: 16px;
     `,
@@ -404,9 +404,7 @@ const SectionTitle = styled.h2`
   padding-left: 24px;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      padding-left: 16px;
-    `,
+    'padding-left: 16px;',
   )};
 `;
 
@@ -424,7 +422,7 @@ const Keyword = styled.li`
   }
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       :last-of-type {
         padding-right: 16px;
       }

--- a/src/components/MultipleLineBooks/MultipleLineBooks.tsx
+++ b/src/components/MultipleLineBooks/MultipleLineBooks.tsx
@@ -46,7 +46,7 @@ const bookWidthStyles = css`
 const Item = styled.li`
   ${orBelow(
     426,
-    css`
+    `
       margin-right: 3px;
       :not(:nth-of-type(3n)) {
         margin-right: 20px;
@@ -56,7 +56,7 @@ const Item = styled.li`
   )};
   ${orBelow(
     432,
-    css`
+    `
       margin-right: 3px;
       :not(:nth-of-type(3n)) {
         margin-right: 20px;
@@ -67,7 +67,7 @@ const Item = styled.li`
   ${between(
     433,
     579,
-    css`
+    `
       :not(:nth-of-type(3n)) {
         margin-right: 4%;
       }
@@ -77,7 +77,7 @@ const Item = styled.li`
   ${between(
     580,
     833,
-    css`
+    `
       :not(:nth-of-type(3n)) {
         margin-right: 16%;
       }
@@ -87,7 +87,7 @@ const Item = styled.li`
   ${between(
     850,
     BreakPoint.LG,
-    css`
+    `
       :not(:nth-of-type(6n)) {
         margin-right: 2.1%;
       }
@@ -96,7 +96,7 @@ const Item = styled.li`
   )};
   ${greaterThanOrEqualTo(
     1001,
-    css`
+    `
       :not(:nth-of-type(6n)) {
         //margin-right: 20px;
         flex-grow: 0;
@@ -111,7 +111,7 @@ const Item = styled.li`
 const thumbnailOverrideStyle = css`
   ${orBelow(
     BreakPoint.SM,
-    css`
+    `
       width: 100%;
       min-width: 70px;
       height: calc(90px * 1.618 - 10px);
@@ -120,7 +120,7 @@ const thumbnailOverrideStyle = css`
   ${between(
     BreakPoint.SM + 1,
     BreakPoint.M,
-    css`
+    `
       width: 100%;
       min-width: 100px;
       height: calc(100px * 1.618 - 10px);
@@ -136,15 +136,11 @@ const bookMetaWrapperStyle = css`
   ${between(
     BreakPoint.M + 1,
     BreakPoint.LG,
-    css`
-      width: 120px;
-    `,
+    'width: 120px;',
   )}
   ${greaterThanOrEqualTo(
     BreakPoint.LG + 1,
-    css`
-      width: 140px;
-    `,
+    'width: 140px;',
   )}
 `;
 
@@ -208,7 +204,7 @@ const Section = styled.section`
   padding-top: 24px;
   ${orBelow(
     433,
-    css`
+    `
       justify-content: space-between;
       padding: 16px 10px;
       padding-right: 29px !important;
@@ -216,7 +212,7 @@ const Section = styled.section`
   )}
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       padding-left: 20px;
       padding-right: 26px;
       padding-top: 16px;
@@ -225,9 +221,7 @@ const Section = styled.section`
   )}
   ${greaterThanOrEqualTo(
     BreakPoint.LG + 1,
-    css`
-      padding-left: 24px;
-    `,
+    'padding-left: 24px;',
   )}
 `;
 
@@ -239,7 +233,7 @@ const List = styled.ul`
   margin-bottom: -24px;
   ${orBelow(
     432,
-    css`
+    `
       justify-content: space-between;
       margin-left: -10px;
     `,
@@ -247,7 +241,7 @@ const List = styled.ul`
   ${between(
     BreakPoint.M + 1,
     BreakPoint.MD,
-    css`
+    `
       justify-content: space-between;
       margin-left: -10px;
     `,
@@ -255,14 +249,14 @@ const List = styled.ul`
   ${between(
     BreakPoint.MD + 1,
     BreakPoint.LG,
-    css`
+    `
       justify-content: space-between;
       margin-left: -6px;
     `,
   )}
   ${greaterThanOrEqualTo(
     BreakPoint.LG + 1,
-    css`
+    `
       left: -19px;
       position: relative;
     `,
@@ -305,9 +299,7 @@ const Title = styled.h2`
   word-break: keep-all;
   ${orBelow(
     BreakPoint.MD,
-    css`
-      margin-left: -2px;
-    `,
+    'margin-left: -2px;',
   )}
 `;
 

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -9,24 +9,18 @@ const pageTitleCSS = css`
   padding: 15px 0;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      padding: 15px 24px;
-    `,
+    'padding: 15px 24px;',
   )};
   ${orBelow(
     BreakPoint.M,
-    css`
-      padding: 15px 16px;
-    `,
+    'padding: 15px 16px;',
   )};
 `;
 
 const mobileDisplayNone = css`
   ${orBelow(
     BreakPoint.LG,
-    css`
-      display: none;
-    `,
+    'display: none;',
   )};
 `;
 

--- a/src/components/Placeholder/NotificationItemPlaceholder.tsx
+++ b/src/components/Placeholder/NotificationItemPlaceholder.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import { RIDITheme } from 'src/styles';
 import { BreakPoint, orBelow } from 'src/utils/mediaQuery';
 
@@ -13,9 +12,7 @@ const NotificationPlaceholderWrap = styled.div<{ opacity: number }, RIDITheme>`
   opacity: ${(props) => props.opacity};
   ${orBelow(
     BreakPoint.LG,
-    css`
-      margin: 0 16px;
-    `,
+    'margin: 0 16px;',
   )};
   ::after {
     content: '';

--- a/src/components/QuickMenu/QuickMenuList.tsx
+++ b/src/components/QuickMenu/QuickMenuList.tsx
@@ -25,7 +25,7 @@ const QuickMenuLabel = styled.span`
   margin-top: 8px;
   ${orBelow(
     BreakPoint.MD,
-    css`
+    `
       min-width: 55px;
       width: 100%;
     `,
@@ -44,7 +44,7 @@ const MenuList = styled.ul`
 
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       padding-top: 16px;
       padding-bottom: 16px;
       padding-left: 3px;
@@ -73,9 +73,7 @@ const MenuItem = styled.li`
 const MenuAnchor = styled.a`
   ${orBelow(
     BreakPoint.LG,
-    css`
-      max-width: 50px;
-    `,
+    'max-width: 50px;',
   )};
   display: flex;
   flex-direction: column;

--- a/src/components/RecommendedBook/RecommendedBookCarousel.tsx
+++ b/src/components/RecommendedBook/RecommendedBookCarousel.tsx
@@ -89,7 +89,7 @@ function RecommendedBookCarousel(props: Omit<RecommendedBookProps, 'title'>) {
               ${arrowWrapperCSS};
               ${greaterThanOrEqualTo(
               BreakPoint.XL + 1,
-              css`left: -31px;`,
+              'left: -31px;',
             )};
               left: 5px;
               top: ${getArrowVerticalCenterPosition()};
@@ -104,7 +104,7 @@ function RecommendedBookCarousel(props: Omit<RecommendedBookProps, 'title'>) {
               ${arrowWrapperCSS};
               ${greaterThanOrEqualTo(
               BreakPoint.XL + 1,
-              css`right: -27px;`,
+              'right: -27px;',
             )};
               right: 5px;
               top: ${getArrowVerticalCenterPosition()};

--- a/src/components/Search/InstantSearch.tsx
+++ b/src/components/Search/InstantSearch.tsx
@@ -49,7 +49,7 @@ const SearchWrapper = styled.div<{}, RIDITheme>`
   line-height: 32px;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       height: 36px;
       line-height: 36px;
       min-width: unset;
@@ -109,7 +109,7 @@ const focused = (theme: RIDITheme) => css`
   order: 2;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       margin-top: 0;
       position: absolute;
       top: 0;
@@ -134,7 +134,7 @@ const initial = () => css`
   order: 2;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       margin-top: 10px;
       order: 3;
     `,
@@ -152,7 +152,7 @@ const SearchFooter = styled.div`
   margin-top: 2px;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       width: 100vw;
       left: 6px;
       box-shadow: unset;
@@ -172,7 +172,7 @@ const dimmer = css`
   display: none;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       display: block;
       position: fixed;
       top: 0;
@@ -193,9 +193,7 @@ const arrow = css`
   height: 16px;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      display: block;
-    `,
+    'display: block;',
   )};
 `;
 
@@ -203,7 +201,7 @@ const ArrowWrapperButton = styled.button`
   display: none;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       display: block;
       padding: 0 11px 0 5px;
     `,
@@ -573,7 +571,7 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
             isFocused ? focused(theme) : initial(),
             css`
               outline: none;
-              ${orBelow(BreakPoint.LG, css`width: 100%;`)}
+              ${orBelow(BreakPoint.LG, 'width: 100%;')}
             `,
           ]}
         >

--- a/src/components/Search/InstantSearchHistory.tsx
+++ b/src/components/Search/InstantSearchHistory.tsx
@@ -19,7 +19,7 @@ const TurnOffSearchHistory = styled.div`
   vertical-align: middle;
   box-sizing: content-box;
   font-size: 14px;
-  color: ${colors.slateGray80}; 
+  color: ${colors.slateGray80};
 `;
 
 const RecentHistoryLabel = styled.p`
@@ -63,7 +63,7 @@ const SearchHistoryItem = styled.li`
   align-items: center;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       :hover {
         background-color: white !important;
       }

--- a/src/components/Search/InstantSearchResult.tsx
+++ b/src/components/Search/InstantSearchResult.tsx
@@ -19,9 +19,7 @@ import {
 const listItemCSS = css`
   ${orBelow(
     BreakPoint.LG,
-    css`
-      min-height: 40px;
-    `,
+    'min-height: 40px;',
   )};
   cursor: pointer;
 `;
@@ -30,7 +28,7 @@ const BookListItem = styled.li`
   ${listItemCSS}
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       :hover {
         background-color: white !important;
       }
@@ -41,7 +39,7 @@ const BookListItem = styled.li`
   )}
   ${greaterThanOrEqualTo(
     BreakPoint.LG + 1,
-    css`
+    `
         :first-of-type {
           border-top-left-radius: 3px;
           border-top-right-radius: 3px;
@@ -72,7 +70,7 @@ const AuthorListItem = styled.li`
   display: flex;
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       :hover {
         background-color: white !important;
       }
@@ -83,7 +81,7 @@ const AuthorListItem = styled.li`
   )};
   ${greaterThanOrEqualTo(
     BreakPoint.LG + 1,
-    css`
+    `
       :first-of-type {
         border-top-left-radius: 3px;
         border-top-right-radius: 3px;
@@ -126,9 +124,7 @@ const BookTitle = styled.span`
   color: ${gray100};
   ${greaterThanOrEqualTo(
     BreakPoint.LG + 1,
-    css`
-      max-width: 298px;
-    `,
+    'max-width: 298px;',
   )};
 `;
 
@@ -152,9 +148,7 @@ const AuthorName = styled.span`
   margin-right: 8px;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      margin-right: 6px;
-    `,
+    'margin-right: 6px;',
   )};
   color: ${gray100};
 `;
@@ -179,9 +173,7 @@ const AuthorPublisher = styled.span`
   margin-right: 5px;
   ${greaterThanOrEqualTo(
     BreakPoint.LG + 1,
-    css`
-      max-width: 298px;
-    `,
+    'max-width: 298px;',
   )}
 `;
 

--- a/src/components/Tabs/GenreTab.tsx
+++ b/src/components/Tabs/GenreTab.tsx
@@ -37,7 +37,7 @@ const Ruler = styled.hr`
 
 const resetPadding = orBelow(
   999,
-  css`
+  `
     padding: 0;
   `,
 );
@@ -79,7 +79,7 @@ const GenreList = styled.ul`
   }
   ${orBelow(
     999,
-    css`
+    `
       justify-content: space-around;
       li {
         flex-grow: 1;

--- a/src/components/Tabs/MainTab.tsx
+++ b/src/components/Tabs/MainTab.tsx
@@ -36,9 +36,7 @@ const Tabs = styled.ul`
   padding: 0 20px;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      padding: 0;
-    `,
+    'padding: 0;',
   )};
 `;
 
@@ -65,7 +63,7 @@ const iconStyle = () => css`
 
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       width: 24px;
       height: 24px;
       margin-right: 0;
@@ -83,7 +81,9 @@ const labelStyle = css`
   text-align: center;
   color: #ffffff;
 
-  ${orBelow(BreakPoint.LG, a11y)};
+  @media (max-width: ${BreakPoint.LG}px) {
+    ${a11y}
+  }
 `;
 
 const BottomLine = styled.span`
@@ -105,7 +105,7 @@ const TabItemWrapper = styled.li`
 
   ${orBelow(
     BreakPoint.LG,
-    css`
+    `
       height: 40px;
       width: 25%;
       :not(:last-of-type) {
@@ -162,9 +162,7 @@ const NotificationAddOn = styled.div`
   background: #ffde24;
   border-radius: 11px;
   background-clip: padding-box;
-  ${orBelow(BreakPoint.LG, css`
-    left: 17.5px;
-  `)};
+  ${orBelow(BreakPoint.LG, 'left: 17.5px;')};
 `;
 
 const CartAddOnWrapper = styled.div`
@@ -179,9 +177,7 @@ const CartAddOnWrapper = styled.div`
   display: flex;
   max-height: 31px;
   height: 100%;
-  ${orBelow(BreakPoint.LG, css`
-    left: 12.5px;
-  `)};
+  ${orBelow(BreakPoint.LG, 'left: 12.5px;')};
 `;
 
 const CartAddOnBackground = styled.div`
@@ -191,9 +187,7 @@ const CartAddOnBackground = styled.div`
   background: white;
   height: 20px;
   display: flex;
-  ${orBelow(BreakPoint.LG, css`
-    margin-left: 4px;
-  `)};
+  ${orBelow(BreakPoint.LG, 'margin-left: 4px;')};
   background-clip: padding-box;
 `;
 

--- a/src/pages/category/list/index.tsx
+++ b/src/pages/category/list/index.tsx
@@ -302,9 +302,7 @@ const sectionCSS = css`
   margin-top: -20px;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      padding: 0;
-    `,
+    'padding: 0;',
   )}
 `;
 const CategoryListPage: React.FC<CategoryListPageProps> & NextComponentType = (props) => {

--- a/src/pages/notification/index.tsx
+++ b/src/pages/notification/index.tsx
@@ -28,9 +28,7 @@ const Section = styled.section<{}, RIDITheme>`
   margin: 0 auto;
   ${orBelow(
     BreakPoint.LG,
-    css`
-      padding: 0;
-    `,
+    'padding: 0;',
   )};
 `;
 
@@ -51,15 +49,11 @@ const NotiListItem = styled.li<{}, RIDITheme>`
 
   ${orBelow(
     BreakPoint.LG,
-    css`
-      padding: 14px 20px;
-    `,
+    'padding: 14px 20px;',
   )};
   ${orBelow(
     BreakPoint.M,
-    css`
-      padding: 14px 16px;
-    `,
+    'padding: 14px 16px;',
   )};
 `;
 
@@ -106,7 +100,7 @@ const ImageWrapper = styled.div<{ imageType: string }>`
   flex-shrink: 0;
   position: relative;
   align-self: flex-start;
-  line-height: 0;  
+  line-height: 0;
   ${(props) => props.imageType === 'book' && BookShadowStyle};
 `;
 
@@ -163,7 +157,7 @@ const NoEmptyNotification = styled.p`
   padding-bottom: 359px;
   ${orBelow(
     BreakPoint.M,
-    css`
+    `
       padding-top: 144px;
       padding-bottom: 200px;
     `,

--- a/src/utils/mediaQuery.ts
+++ b/src/utils/mediaQuery.ts
@@ -1,5 +1,3 @@
-import { css, SerializedStyles } from '@emotion/core';
-
 export enum BreakPoint {
   XS = 299,
   SM = 374,
@@ -10,21 +8,21 @@ export enum BreakPoint {
 }
 
 // 특정 width 이하
-export const orBelow = (width: number, style: SerializedStyles) => css`
+export const orBelow = (width: number, style: string) => `
   @media (max-width: ${width}px) {
     ${style};
   }
 `;
 
 // min 이상부터 max 이하까지
-export const between = (min: number, max: number, style: SerializedStyles) => css`
+export const between = (min: number, max: number, style: string) => `
   @media (min-width: ${min}px) and (max-width: ${max}px) {
     ${style};
   }
 `;
 
 // 특정 width 이상
-export const greaterThanOrEqualTo = (width: number, style: SerializedStyles) => css`
+export const greaterThanOrEqualTo = (width: number, style: string) => `
   @media (min-width: ${width}px) {
     ${style};
   }


### PR DESCRIPTION
기존에는
```
css`
  ${css`
    ${css`
    `}
  `}
`
```
이런 식이었던 것을 하나의 `css`가 되도록 합니다. 다중으로 들어가니까 디버그 빌드에서 클래스명이 난리가 나더라고요...