### PR TITLE
keyframes 를 css`` 사이에 놓도록 수정

### DIFF
--- a/src/components/Search/InstantSearch.tsx
+++ b/src/components/Search/InstantSearch.tsx
@@ -119,12 +119,14 @@ const focused = (theme: RIDITheme) => css`
       width: 100%;
       padding: 6px;
       box-sizing: border-box;
-      animation: ${fadeIn} 0.2s ease-in-out;
       display: flex;
       align-items: center;
       order: 3;
     `,
   )};
+  @media (max-width: ${BreakPoint.LG}px) {
+    animation: ${fadeIn} 0.2s ease-in-out;
+  }
 `;
 
 const initial = () => css`


### PR DESCRIPTION
https://github.com/ridi/books-frontend/pull/200 과 비슷한 이슈입니다. 
`keyframes` 가 적용 된 css 일 경우 밖으로 빼주었음
