### PR TITLE
통합 검색 페이지에 저자 목록 표시

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "reselect": "^4.0.0",
     "sentry-testkit": "^3.2.0",
     "serverless-http": "^2.3.0",
-    "ts-get": "^1.0.5",
     "ua-parser-js": "^0.7.20",
     "universal-cookie": "^4.0.3",
     "url": "^0.11.0",

--- a/src/components/Search/InstantSearch.tsx
+++ b/src/components/Search/InstantSearch.tsx
@@ -215,8 +215,8 @@ interface InstantSearchProps {
 }
 
 const initialSearchResult = {
-  book: { books: [] },
-  author: { authors: [] },
+  books: [],
+  authors: [],
 };
 
 export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
@@ -254,8 +254,8 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
 
         const result = await pRetry(() => axios.get(url.toString()), { retries: 2 });
         setSearchResult({
-          book: result?.data?.book ?? {},
-          author: result?.data?.author ?? {},
+          books: result.data.book.books ?? [],
+          authors: result.data.author.authors ?? [],
         });
       } catch (error) {
         setSearchResult(initialSearchResult);
@@ -460,7 +460,7 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
           ).slice(0, 5);
           const total = inputRef.current.value.length < 1
             ? history.length
-            : searchResult.book.books.length + searchResult.author.authors.length;
+            : searchResult.authors.length + searchResult.books.length;
           if (e.which === 40) {
             // keyDown
             const nextPos = focusedPosition + 1;
@@ -476,8 +476,8 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
       [
         handleSetCurrentPosition,
         focusedPosition,
-        searchResult.author.authors.length,
-        searchResult.book.books.length,
+        searchResult.authors.length,
+        searchResult.books.length,
       ],
     );
     useEffect(() => {
@@ -513,15 +513,15 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
       () =>
         // eslint-disable-next-line
         ((keyword.length < 1 && searchHistory.length > 0) ||
-          searchResult.book.books.length > 0
-          || searchResult.author.authors.length > 0)
+          searchResult.books.length > 0
+          || searchResult.authors.length > 0)
         && isFocused,
       [
         isFocused,
         keyword.length,
         searchHistory.length,
-        searchResult.author.authors.length,
-        searchResult.book.books.length,
+        searchResult.authors.length,
+        searchResult.books.length,
       ],
     );
 

--- a/src/components/Search/InstantSearch.tsx
+++ b/src/components/Search/InstantSearch.tsx
@@ -14,13 +14,13 @@ import { safeJSONParse } from 'src/utils/common';
 import axios from 'axios';
 import InstantSearchResult from 'src/components/Search/InstantSearchResult';
 import InstantSearchHistory from 'src/components/Search/InstantSearchHistory';
-import { get } from 'ts-get';
 import { BreakPoint, orBelow } from 'src/utils/mediaQuery';
 import pRetry from 'p-retry';
 import sentry from 'src/utils/sentry';
 import styled from '@emotion/styled';
 import { useTheme } from 'emotion-theming';
 import { GNBContext } from 'src/components/GNB';
+import * as SearchResult from 'src/types/searchResults';
 
 const fadeIn = keyframes`
   0% {
@@ -210,51 +210,13 @@ const ArrowWrapperButton = styled.button`
   )};
 `;
 
-export interface AuthorInfo {
-  author_id: number;
-  b_id: string;
-  name: string;
-  order: number;
-  role: 'author' | 'translator' | 'illustrator';
-}
-
-export interface InstantSearchBookResultScheme {
-  b_id: string;
-  highlight: {
-    web_title_title?: string;
-    author_title_title?: string;
-  };
-  web_title_title?: string;
-  author_title_title?: string;
-  author: string;
-  author2: string;
-  authors_info: AuthorInfo[];
-  publisher: string;
-  age_limit: number;
-}
-
-export interface InstantSearchAuthorResultScheme {
-  popular_book_title: string;
-  book_count: number;
-  name: string;
-  id: number;
-  highlight: {
-    name: string;
-  };
-}
-
-export interface InstantSearchResultScheme {
-  books: InstantSearchBookResultScheme[];
-  authors: InstantSearchAuthorResultScheme[];
-}
-
 interface InstantSearchProps {
   searchKeyword: string;
 }
 
 const initialSearchResult = {
-  books: [],
-  authors: [],
+  book: { books: [] },
+  author: { authors: [] },
 };
 
 export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
@@ -270,7 +232,7 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
     const [focusedPosition, setFocusedPosition] = useState(0);
     const [, setFetching] = useState(false);
 
-    const [searchResult, setSearchResult] = useState<InstantSearchResultScheme>(
+    const [searchResult, setSearchResult] = useState<SearchResult.InstantSearchResult>(
       initialSearchResult,
     );
 
@@ -292,8 +254,8 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
 
         const result = await pRetry(() => axios.get(url.toString()), { retries: 2 });
         setSearchResult({
-          books: get(result.data, (data) => data.book.books, []),
-          authors: get(result.data, (data) => data.author.authors, []),
+          book: result?.data?.book ?? {},
+          author: result?.data?.author ?? {},
         });
       } catch (error) {
         setSearchResult(initialSearchResult);
@@ -498,7 +460,7 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
           ).slice(0, 5);
           const total = inputRef.current.value.length < 1
             ? history.length
-            : searchResult.authors.length + searchResult.books.length;
+            : searchResult.book.books.length + searchResult.author.authors.length;
           if (e.which === 40) {
             // keyDown
             const nextPos = focusedPosition + 1;
@@ -514,8 +476,8 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
       [
         handleSetCurrentPosition,
         focusedPosition,
-        searchResult.authors.length,
-        searchResult.books.length,
+        searchResult.author.authors.length,
+        searchResult.book.books.length,
       ],
     );
     useEffect(() => {
@@ -551,15 +513,15 @@ export const InstantSearch: React.FC<InstantSearchProps> = React.memo(
       () =>
         // eslint-disable-next-line
         ((keyword.length < 1 && searchHistory.length > 0) ||
-          searchResult.books.length > 0
-          || searchResult.authors.length > 0)
+          searchResult.book.books.length > 0
+          || searchResult.author.authors.length > 0)
         && isFocused,
       [
         isFocused,
         keyword.length,
         searchHistory.length,
-        searchResult.authors.length,
-        searchResult.books.length,
+        searchResult.author.authors.length,
+        searchResult.book.books.length,
       ],
     );
 

--- a/src/components/Search/InstantSearchResult.tsx
+++ b/src/components/Search/InstantSearchResult.tsx
@@ -11,10 +11,7 @@ import { ADULT_BADGE_URL, AUTHOR_ICON_URL } from 'src/constants/icons';
 import * as SearchResult from 'src/types/searchResults';
 
 const listItemCSS = css`
-  ${orBelow(
-    BreakPoint.LG,
-    'min-height: 40px;',
-  )};
+  ${orBelow(BreakPoint.LG, 'min-height: 40px;')};
   cursor: pointer;
 `;
 
@@ -116,10 +113,7 @@ const BookTitle = styled.span`
   word-break: keep-all;
   margin-right: 6px;
   color: ${gray100};
-  ${greaterThanOrEqualTo(
-    BreakPoint.LG + 1,
-    'max-width: 298px;',
-  )};
+  ${greaterThanOrEqualTo(BreakPoint.LG + 1, 'max-width: 298px;')};
 `;
 
 const authorPublisherCSS = css`
@@ -140,10 +134,7 @@ const AuthorName = styled.span`
   line-height: 1.4em;
   flex-shrink: 0;
   margin-right: 8px;
-  ${orBelow(
-    BreakPoint.LG,
-    'margin-right: 6px;',
-  )};
+  ${orBelow(BreakPoint.LG, 'margin-right: 6px;')};
   color: ${gray100};
 `;
 
@@ -165,10 +156,7 @@ const AuthorPublisher = styled.span`
   font-size: 13px;
   padding-left: 5px;
   margin-right: 5px;
-  ${greaterThanOrEqualTo(
-    BreakPoint.LG + 1,
-    'max-width: 298px;',
-  )}
+  ${greaterThanOrEqualTo(BreakPoint.LG + 1, 'max-width: 298px;')}
 `;
 
 const InstantSearchDivider = styled.hr`
@@ -299,7 +287,7 @@ function InstantSearchResult(props: InstantSearchResultProps) {
     focusedPosition,
     handleClickAuthorItem,
     handleClickBookItem,
-    result,
+    result: { authors, books },
     handleKeyDown,
   } = props;
   const wrapperRef = React.useRef<HTMLDivElement>();
@@ -313,14 +301,13 @@ function InstantSearchResult(props: InstantSearchResultProps) {
         }
       }
     }
-  }, [focusedPosition, result]);
-
+  }, [focusedPosition, authors, books]);
   return (
     <ResultWrapper ref={wrapperRef}>
-      {result.author.authors.length > 0 && (
+      {authors.length > 0 && (
         <>
           <ul>
-            {result.author.authors.map((author, index) => (
+            {authors.map((author, index) => (
               <AuthorListItem key={index}>
                 <AuthorListItemButton
                   type="button"
@@ -336,17 +323,15 @@ function InstantSearchResult(props: InstantSearchResultProps) {
           <InstantSearchDivider />
         </>
       )}
-      {result.book.books.length > 0 && (
+      {books.length > 0 && (
         <BookList
           handleClickBookItem={handleClickBookItem}
           handleKeyDown={handleKeyDown}
-          result={result.book.books}
+          result={books}
         />
       )}
     </ResultWrapper>
   );
 }
 
-const MemoizedInstantSearchResult: React.FC<InstantSearchResultProps> = React.memo(InstantSearchResult);
-
-export default MemoizedInstantSearchResult;
+export default React.memo(InstantSearchResult);

--- a/src/components/Search/InstantSearchResult.tsx
+++ b/src/components/Search/InstantSearchResult.tsx
@@ -8,13 +8,7 @@ import {
   slateGray50, slateGray5, lightSteelBlue5, gray100,
 } from '@ridi/colors';
 import { ADULT_BADGE_URL, AUTHOR_ICON_URL } from 'src/constants/icons';
-
-import {
-  AuthorInfo as AuthorInfoScheme,
-  InstantSearchAuthorResultScheme,
-  InstantSearchBookResultScheme,
-  InstantSearchResultScheme,
-} from './InstantSearch';
+import * as SearchResult from 'src/types/searchResults';
 
 const listItemCSS = css`
   ${orBelow(
@@ -212,7 +206,7 @@ const Divider = styled.div`
 `;
 
 interface InstantSearchResultProps {
-  result: InstantSearchResultScheme;
+  result: SearchResult.InstantSearchResult;
   handleKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   handleClickAuthorItem: (e: React.MouseEvent<HTMLButtonElement>) => void;
   handleClickBookItem: (e: React.MouseEvent<HTMLButtonElement>) => void;
@@ -220,12 +214,12 @@ interface InstantSearchResultProps {
 }
 
 interface InstantSearchResultBookListProps {
-  result: InstantSearchResultScheme;
+  result: SearchResult.SearchBookDetail[];
   handleKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   handleClickBookItem: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-const AuthorInfo: React.FC<{ author: InstantSearchAuthorResultScheme }> = (props) => {
+export const AuthorInfo: React.FC<{ author: SearchResult.Author }> = (props) => {
   const { author } = props;
 
   return (
@@ -245,7 +239,7 @@ const AuthorInfo: React.FC<{ author: InstantSearchAuthorResultScheme }> = (props
 };
 
 // Todo 사용 컴포넌트마다 다른 options 사용해서 보여주기
-const AuthorLabel: React.FC<{ author: string; authors: AuthorInfoScheme[] }> = (props) => {
+const AuthorLabel: React.FC<{ author: string; authors: SearchResult.AuthorsInfo[] }> = (props) => {
   const viewedAuthors = props.authors
     && props.authors
       .filter((author) => author.role === 'author' || author.role === 'illustrator')
@@ -267,7 +261,7 @@ const BookList: React.FC<InstantSearchResultBookListProps> = React.memo((props) 
   const { result, handleKeyDown, handleClickBookItem } = props;
   return (
     <ul>
-      {result.books.map((book: InstantSearchBookResultScheme, index) => (
+      {result.map((book: SearchResult.SearchBookDetail, index) => (
         <BookListItem data-book-id={book.b_id} key={index}>
           <BookListItemButton
             type="button"
@@ -300,7 +294,7 @@ const ResultWrapper = styled.div`
   padding: 4px 0;
 `;
 
-const InstantSearchResult: React.FC<InstantSearchResultProps> = React.memo((props) => {
+function InstantSearchResult(props: InstantSearchResultProps) {
   const {
     focusedPosition,
     handleClickAuthorItem,
@@ -323,10 +317,10 @@ const InstantSearchResult: React.FC<InstantSearchResultProps> = React.memo((prop
 
   return (
     <ResultWrapper ref={wrapperRef}>
-      {result.authors.length > 0 && (
+      {result.author.authors.length > 0 && (
         <>
           <ul>
-            {result.authors.map((author, index) => (
+            {result.author.authors.map((author, index) => (
               <AuthorListItem key={index}>
                 <AuthorListItemButton
                   type="button"
@@ -342,15 +336,17 @@ const InstantSearchResult: React.FC<InstantSearchResultProps> = React.memo((prop
           <InstantSearchDivider />
         </>
       )}
-      {result.books.length > 0 && (
+      {result.book.books.length > 0 && (
         <BookList
           handleClickBookItem={handleClickBookItem}
           handleKeyDown={handleKeyDown}
-          result={result}
+          result={result.book.books}
         />
       )}
     </ResultWrapper>
   );
-});
+}
 
-export default InstantSearchResult;
+const MemoizedInstantSearchResult: React.FC<InstantSearchResultProps> = React.memo(InstantSearchResult);
+
+export default MemoizedInstantSearchResult;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -56,7 +56,8 @@ function Authors(props: { author: SearchTypes.AuthorResult }) {
           <AuthorInfo author={author} />
         </AuthorItem>
       ))}
-      {isCollapsed && <span>ho</span>}
+      {/* Todo 더 보기 */}
+      {isCollapsed && <span>더 보기</span>}
     </AuthorList>
   );
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -8,12 +8,13 @@ import { AuthorInfo } from 'src/components/Search/InstantSearchResult';
 import { slateGray40, slateGray60, slateGray90 } from '@ridi/colors';
 import ArrowBoldH from 'src/svgs/ArrowBoldH.svg';
 import { BreakPoint, orBelow } from 'src/utils/mediaQuery';
+import isPropValid from '@emotion/is-prop-valid';
 
 interface SearchProps {
   q?: string;
   book?: SearchTypes.BookResult;
   author?: SearchTypes.AuthorResult;
-  categories?: SearchTypes.Aggregation;
+  categories?: SearchTypes.Aggregation[];
 }
 
 const SearchResultSection = styled.section`
@@ -29,12 +30,7 @@ const SearchTitle = styled.h3`
   display: flex;
   align-items: center;
   padding: 10px 0;
-  ${orBelow(
-    BreakPoint.LG,
-    `
-    padding: 10px 16px;
-  `,
-  )}
+  ${orBelow(BreakPoint.LG, 'padding: 10px 16px;')}
 `;
 
 const TotalAuthor = styled.span`
@@ -52,12 +48,7 @@ const AuthorItem = styled.li<{ show: boolean }>`
 
 const AuthorList = styled.ul`
   margin-bottom: 16px;
-  ${orBelow(
-    BreakPoint.LG,
-    `
-    padding: 0 16px;
-  `,
-  )}
+  ${orBelow(BreakPoint.LG, 'padding: 10px 16px;')}
 `;
 
 const ShowMoreAuthor = styled.li`
@@ -72,11 +63,13 @@ const ShowMoreAuthor = styled.li`
 const MAXIMUM_AUTHOR = 30;
 const DEFAULT_SHOW_AUTHOR_COUNT = 3;
 
-const Arrow = styled(ArrowBoldH)<{ isRotate: boolean }>`
+const Arrow = styled(ArrowBoldH, {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'isRotate',
+})<{ isRotate: boolean }>`
   width: 11px;
   fill: ${slateGray40};
   margin-left: 5px;
-  transform: rotate(${(props) => (props.isRotate ? '180deg' : '')});
+  transform: rotate(${(props) => (props.isRotate ? '180deg' : '0deg')});
 `;
 
 function Authors(props: { author: SearchTypes.AuthorResult; q: string }) {
@@ -92,25 +85,25 @@ function Authors(props: { author: SearchTypes.AuthorResult; q: string }) {
     <AuthorList>
       {authorsPreview.map((author) => (
         <AuthorItem key={author.id} show>
-          <a href={`/author/${author.id}?_s=search&_q=${q}`}>
+          <a href={`/author/${author.id}?_s=search&_q=${encodeURIComponent(q)}`}>
             <AuthorInfo author={author} />
           </a>
         </AuthorItem>
       ))}
       {restAuthors.map((author) => (
         <AuthorItem key={author.id} show={isShowMore}>
-          <a href={`/author/${author.id}?_s=search&_q=${q}`}>
+          <a href={`/author/${author.id}?_s=search&_q=${encodeURIComponent(q)}`}>
             <AuthorInfo author={author} />
           </a>
         </AuthorItem>
       ))}
       {authors.length > DEFAULT_SHOW_AUTHOR_COUNT && (
-        <ShowMoreAuthor onClick={() => setShowMore(!isShowMore)}>
+        <ShowMoreAuthor onClick={() => setShowMore((current) => !current)}>
           {isShowMore ? (
             <span>접기</span>
           ) : (
             <span>
-              {total > MAXIMUM_AUTHOR ? MAXIMUM_AUTHOR - DEFAULT_SHOW_AUTHOR_COUNT : total - DEFAULT_SHOW_AUTHOR_COUNT}
+              {Math.min(total, MAXIMUM_AUTHOR) - DEFAULT_SHOW_AUTHOR_COUNT}
               명 더 보기
             </span>
           )}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -4,6 +4,7 @@ import { ConnectedInitializeProps } from 'src/types/common';
 import styled from '@emotion/styled';
 import axios from 'src/utils/axios';
 import * as SearchTypes from 'src/types/searchResults';
+import { AuthorInfo } from 'src/components/Search/InstantSearchResult';
 
 interface SearchProps {
   q?: string;
@@ -17,7 +18,20 @@ const SearchResultSection = styled.section`
   margin: 0 auto;
 `;
 
+function AuthorList(props: { author: SearchTypes.AuthorResult }) {
+  return (
+    <ul>
+      {props.author.authors.map((author) => (
+        <AuthorInfo author={author} />
+      ))}
+    </ul>
+  );
+}
+
 function SearchPage(props: SearchProps) {
+  const {
+    author, book, categories, q,
+  } = props;
   return (
     <SearchResultSection>
       <Head>
@@ -27,12 +41,11 @@ function SearchPage(props: SearchProps) {
           검색 결과 - 리디북스
         </title>
       </Head>
-      <div>
-        <h3>검색 결과</h3>
-        {props.book?.books.map((book) => (
-          <span key={book.b_id}>{book.title}</span>
-        ))}
-      </div>
+      {props.author.total > 0 && <AuthorList author={author} />}
+      <h3>검색 결과</h3>
+      {props.book?.books.map((item) => (
+        <span key={item.b_id}>{item.title}</span>
+      ))}
     </SearchResultSection>
   );
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import axios from 'src/utils/axios';
 import * as SearchTypes from 'src/types/searchResults';
 import { AuthorInfo } from 'src/components/Search/InstantSearchResult';
+import { slateGray40, slateGray90 } from '@ridi/colors';
 
 interface SearchProps {
   q?: string;
@@ -18,13 +19,45 @@ const SearchResultSection = styled.section`
   margin: 0 auto;
 `;
 
-function AuthorList(props: { author: SearchTypes.AuthorResult }) {
+const SearchTitle = styled.h3`
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 21px;
+  color: ${slateGray90};
+  display: flex;
+  align-items: center;
+  padding: 10px 0;
+`;
+
+const TotalAuthor = styled.span`
+  font-size: 13px;
+  font-weight: normal;
+  margin-left: 5px;
+  color: ${slateGray40};
+`;
+
+const AuthorItem = styled.li`
+  padding: 12px 0;
+  display: flex;
+  align-items: center;
+`;
+
+const AuthorList = styled.ul`
+  margin-bottom: 16px;
+`;
+
+function Authors(props: { author: SearchTypes.AuthorResult }) {
+  const [isCollapsed, setCollapse] = React.useState(props.author.total > 30);
+
   return (
-    <ul>
+    <AuthorList>
       {props.author.authors.map((author) => (
-        <AuthorInfo author={author} />
+        <AuthorItem key={author.id}>
+          <AuthorInfo author={author} />
+        </AuthorItem>
       ))}
-    </ul>
+      {isCollapsed && <span>ho</span>}
+    </AuthorList>
   );
 }
 
@@ -41,11 +74,25 @@ function SearchPage(props: SearchProps) {
           검색 결과 - 리디북스
         </title>
       </Head>
-      {props.author.total > 0 && <AuthorList author={author} />}
-      <h3>검색 결과</h3>
-      {props.book?.books.map((item) => (
-        <span key={item.b_id}>{item.title}</span>
-      ))}
+      {props.author.total > 0 && (
+        <>
+          <SearchTitle>
+            {`‘${q}’ 저자 검색 결과`}
+            <TotalAuthor>
+              {author.total > 30 ? '총 30명+' : `총 ${author.total}명`}
+            </TotalAuthor>
+          </SearchTitle>
+          <Authors author={author} />
+        </>
+      )}
+      {props.book.total > 0 && (
+        <>
+          <SearchTitle>{`‘${q}’ 도서 검색 결과`}</SearchTitle>
+          {props.book?.books.map((item) => (
+            <span key={item.b_id}>{item.title}</span>
+          ))}
+        </>
+      )}
     </SearchResultSection>
   );
 }

--- a/src/svgs/ArrowBoldH.svg
+++ b/src/svgs/ArrowBoldH.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 16">
+  <path d="M17.88 2.88L10 10.76 2.12 2.88 0 5l10 10L20 5z"/>
+</svg>

--- a/src/tests/pages/search/Index.spec.tsx
+++ b/src/tests/pages/search/Index.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Index from 'src/pages/search';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import makeStore from 'src/store/config';
 import axios from 'axios';
@@ -47,6 +47,30 @@ describe('Search Page Test', () => {
     const { getByText } = render(<Index {...props} />);
     expect(getByText(/미남들과 함께 가는 성교육 1화*/)).toHaveTextContent(
       '<[미즈] 미남들과 함께 가는 성교육 1화> 외 11권',
+    );
+  });
+
+  it('should be clickable show more authors button', async () => {
+    (axios as any).__setHandler((method: string, url: string) => {
+      return {
+        data: fixture,
+      };
+    });
+
+    const props = await Index.getInitialProps({
+      pathname: 'search',
+      isServer: true,
+      asPath: '',
+      store,
+      query: { q: '유유' },
+    });
+
+    const { getByText } = render(<Index {...props} />);
+    const container = getByText(/명 더 보기/);
+    expect(getByText(/명 더 보기/)).toHaveTextContent('명 더 보기')
+    fireEvent.click(container, {});
+    expect(getByText(/접기/)).toHaveTextContent(
+      '접기',
     );
   });
 });

--- a/src/tests/pages/search/Index.spec.tsx
+++ b/src/tests/pages/search/Index.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Index from 'src/pages/search';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { act, render, cleanup, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import makeStore from 'src/store/config';
 import axios from 'axios';
@@ -10,67 +10,76 @@ const store = makeStore({}, { asPath: 'test', isServer: true });
 
 describe('Search Page Test', () => {
   afterEach(cleanup);
-  it('should be render Search Home', async () => {
-    (axios as any).__setHandler((method: string, url: string) => {
-      return {
-        data: fixture,
-      };
+
+  describe('getInitialProps test', () => {
+    it('should be have server side props', async () => {
+      (axios as any).__setHandler((method: string, url: string) => {
+        return {
+          data: fixture,
+        };
+      });
+      const props = await Index.getInitialProps({
+        pathname: 'search',
+        isServer: true,
+        asPath: '',
+        store,
+        query: { q: '유유' },
+      });
+      expect(props.book.total).toEqual(fixture.book.total);
     });
 
-    const props = await Index.getInitialProps({
-      pathname: 'search',
-      isServer: true,
-      asPath: '',
-      store,
-      query: { q: '유유' },
+    it('should be have client side props', async () => {
+      (axios as any).__setHandler((method: string, url: string) => {
+        return {
+          data: fixture,
+        };
+      });
+      const props = await Index.getInitialProps({
+        pathname: 'search',
+        isServer: false,
+        asPath: '',
+        store,
+        query: { q: '유유' },
+      });
+      // FIXME client side fetch 아직 없음
+      expect(props.book?.total).toBeUndefined();
     });
-
-    const { getByText } = render(<Index {...props} />);
-    expect(getByText(/^유유상종$/)).toHaveTextContent('유유상');
   });
 
-  it('should be render authors`s popular book', async () => {
-    (axios as any).__setHandler((method: string, url: string) => {
-      return {
-        data: fixture,
-      };
+  describe('render test', () => {
+    it('should be render authors`s popular book', async () => {
+      const { getByText } = render(
+        <Index
+          q={'유유'}
+          book={fixture.book}
+          author={fixture.author}
+          categories={fixture.book.aggregations}
+        />,
+      );
+      expect(getByText(/미남들과 함께 가는 성교육 1화/)).toHaveTextContent(
+        '<[미즈] 미남들과 함께 가는 성교육 1화> 외 11권',
+      );
     });
-
-    const props = await Index.getInitialProps({
-      pathname: 'search',
-      isServer: true,
-      asPath: '',
-      store,
-      query: { q: '유유' },
-    });
-
-    const { getByText } = render(<Index {...props} />);
-    expect(getByText(/미남들과 함께 가는 성교육 1화*/)).toHaveTextContent(
-      '<[미즈] 미남들과 함께 가는 성교육 1화> 외 11권',
-    );
   });
 
   it('should be clickable show more authors button', async () => {
-    (axios as any).__setHandler((method: string, url: string) => {
-      return {
-        data: fixture,
-      };
-    });
-
-    const props = await Index.getInitialProps({
-      pathname: 'search',
-      isServer: true,
-      asPath: '',
-      store,
-      query: { q: '유유' },
-    });
-
-    const { getByText } = render(<Index {...props} />);
-    const container = getByText(/명 더 보기/);
-    expect(getByText(/명 더 보기/)).toHaveTextContent('명 더 보기')
-    fireEvent.click(container, {});
-    expect(getByText(/접기/)).toHaveTextContent(
-      '접기',
+    const { getByText } = render(
+      <Index
+        q={'유유'}
+        book={fixture.book}
+        author={fixture.author}
+        categories={fixture.book.aggregations}
+      />,
     );
+    const container = getByText(/명 더 보기/);
+    expect(container).toHaveTextContent('명 더 보기');
+    act(() => {
+      fireEvent.click(container, {});
+    });
+
+    expect(container).toHaveTextContent('접기');
   });
+
+  // Todo 저자가 없을 경우, 도서가 없을 경우
+  it.todo('should be render empty state');
 });

--- a/src/tests/pages/search/Index.spec.tsx
+++ b/src/tests/pages/search/Index.spec.tsx
@@ -25,8 +25,28 @@ describe('Search Page Test', () => {
       query: { q: '유유' },
     });
 
-
-    const { getByText, container } = render(<Index {...props} />);
+    const { getByText } = render(<Index {...props} />);
     expect(getByText(/^유유상종$/)).toHaveTextContent('유유상');
+  });
+
+  it('should be render authors`s popular book', async () => {
+    (axios as any).__setHandler((method: string, url: string) => {
+      return {
+        data: fixture,
+      };
+    });
+
+    const props = await Index.getInitialProps({
+      pathname: 'search',
+      isServer: true,
+      asPath: '',
+      store,
+      query: { q: '유유' },
+    });
+
+    const { getByText } = render(<Index {...props} />);
+    expect(getByText(/미남들과 함께 가는 성교육 1화*/)).toHaveTextContent(
+      '<[미즈] 미남들과 함께 가는 성교육 1화> 외 11권',
+    );
   });
 });

--- a/src/types/searchResults.ts
+++ b/src/types/searchResults.ts
@@ -1,3 +1,5 @@
+import { AuthorRole } from 'src/types/book';
+
 export interface Author {
   popular_book_title: string;
   book_count: number;
@@ -38,7 +40,7 @@ export interface SeriesPriceInfo {
 }
 
 export interface AuthorsInfo {
-  role: string;
+  role: AuthorRole;
   name: string;
   author_id: number;
   native_name: string;
@@ -97,4 +99,12 @@ export interface BookResult {
 export interface SearchResult {
   author: AuthorResult;
   book: BookResult;
+}
+
+export type InstantSearchBookResult = Omit<BookResult, 'total' | 'aggregations'>;
+export type InstantSearchAuthorResult = Omit<AuthorResult, 'total'>;
+
+export interface InstantSearchResult {
+  book: InstantSearchBookResult;
+  author: InstantSearchAuthorResult;
 }

--- a/src/types/searchResults.ts
+++ b/src/types/searchResults.ts
@@ -106,6 +106,6 @@ export type InstantSearchBookResult = Omit<BookResult, 'total' | 'aggregations'>
 export type InstantSearchAuthorResult = Omit<AuthorResult, 'total'>;
 
 export interface InstantSearchResult {
-  book: InstantSearchBookResult;
-  author: InstantSearchAuthorResult;
+  books: InstantSearchBookResult['books'];
+  authors: InstantSearchAuthorResult['authors'];
 }

--- a/src/types/searchResults.ts
+++ b/src/types/searchResults.ts
@@ -40,10 +40,11 @@ export interface SeriesPriceInfo {
 }
 
 export interface AuthorsInfo {
-  role: AuthorRole;
+  role: AuthorRole | string;
   name: string;
   author_id: number;
-  native_name: string;
+  native_name?: string;
+  alias_name?: string;
   order: number;
 }
 
@@ -76,7 +77,7 @@ export interface SearchBookDetail {
   is_rental: boolean;
   author2: string;
   book_count: number;
-  web_title: number;
+  web_title: string;
   b_id: string;
   price: number;
   _score?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13090,11 +13090,6 @@ tryer@^1.0.0:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-ts-get@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/ts-get/-/ts-get-1.0.5.tgz#86789d19fcde7927d59c093c39628059d6bdb0ec"
-  integrity sha512-XSAMqdnAE2u2OudAkJgokzegSZnmoYBOr0z7/ZSDJm9bxeK0jA6W8WmRwm8Rd5rrBOvwXjm/H3zZzsKBBlJPoA==
-
 ts-pnp@^1.1.2:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"


### PR DESCRIPTION
- [x] 인스턴트 검색 타입스크립트 타이핑 부분과 중복되는 부분 searchResult.ts 쪽으로 통합
- [x] 저자 목록 표시 
- [x] ts-get 패키지 삭제 (https://github.com/ridi/books-frontend/compare/feature/search-page-authors?expand=1#diff-eaf4da664f29acfc92bce5f9e23b42a1R257-R258)
- [x] 반응형 스타일링
- [x] 작가 더 보기 Collapse 토글

![image](https://user-images.githubusercontent.com/45959991/78746923-10666e80-79a3-11ea-85f9-06f5ead70369.png)

![image](https://user-images.githubusercontent.com/45959991/78867328-e16ffb80-7a7b-11ea-833d-6439de898e8d.png)
![image](https://user-images.githubusercontent.com/45959991/78867350-ef258100-7a7b-11ea-9ac7-1fc51c70ae86.png)
