### PR TITLE
name 이 없는 경우가 있어 optional chaining 추가

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -92,7 +92,7 @@ class StoreApp extends App<StoreAppProps, StoreAppState> {
       this.serviceWorkerInit();
     }
     // Windows에서만 웹폰트 로드
-    if (new UAParser().getOS().name.toLowerCase().includes('windows')) {
+    if (new UAParser().getOS().name?.toLowerCase().includes('windows')) {
       const WebFont = await import('webfontloader');
       WebFont.load({
         google: {


### PR DESCRIPTION
타입정의가 이렇네요 `name: string | undefined`
_app.tsx test 에서 깨져서 추가하였습니다.
