### PR TITLE
Hotfix/section 이름 앞에 deviceType 붙임

### DIFF
--- a/src/components/TopBanner.tsx
+++ b/src/components/TopBanner.tsx
@@ -241,12 +241,14 @@ function CarouselItem(props: CarouselItemProps) {
   const [intersecting, setIntersecting] = React.useState(false);
   const ref = useViewportIntersection<HTMLLIElement>(setIntersecting);
   const [tracker] = useEventTracker();
+  const { deviceType } = useDeviceType();
+
   const handleBannerClick = React.useCallback(() => {
     tracker.sendEvent(SendEventType.Click, {
-      section: slug,
+      section: `${deviceType}.${slug}`,
       items: [{ id: banner.id, idx: banner.list_order, ts: Date.now() }],
     });
-  }, [banner, slug, tracker]);
+  }, [banner, slug, tracker, deviceType]);
 
   return (
     <CarouselItemContainer


### PR DESCRIPTION
### 관련 태스크
https://app.asana.com/0/inbox/947013990233241/1169770282002785/1170789026778344

slug 앞에 `deviceType` 이 빠져서 트래킹이 안되고 있었습니다.
