### PR TITLE
검색 페이지 카테고리 탭

### DIFF
--- a/src/components/ScrollContainer.tsx
+++ b/src/components/ScrollContainer.tsx
@@ -21,11 +21,11 @@ const SlidingContainer = styled.div`
 
 const Marker = styled.div`
   flex: none;
-  width: 0;
+  width: 1px;
 `;
 
 const Content = styled.div`
-  flex: 1;
+  flex: 1 0 auto;
 `;
 
 const SliderControllerContainer = styled.div`

--- a/src/components/Tabs/SearchCategoryTab.tsx
+++ b/src/components/Tabs/SearchCategoryTab.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import * as SearchTypes from 'src/types/searchResults';
+import styled from '@emotion/styled';
+import { slateGray20, slateGray40 } from '@ridi/colors';
+import ScrollContainer from 'src/components/ScrollContainer';
+import { scrollBarHidden } from 'src/styles';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+interface SearchCategoryProps {
+  categories: SearchTypes.Aggregation[];
+  currentCategory: string;
+}
+
+const CategoryList = styled.ul`
+  display: flex;
+  max-width: 952px;
+  border-bottom: 1px solid ${slateGray20};
+  overflow-x: auto;
+  height: 45px;
+  ${scrollBarHidden}
+`;
+
+const CategoryItem = styled.li<{ active: boolean }>`
+  flex: none;
+  display: flex;
+  justify-content: space-between;
+  :not(:first-of-type) {
+    margin-left: 10px;
+  }
+  box-shadow: ${(props) => (props.active ? `inset 0px -3px 0px ${slateGray40}` : 'none')};
+
+  cursor: pointer;
+`;
+
+const CategoryAnchor = styled.a`
+  padding: 15px 4px;
+`;
+
+function SearchCategoryTab(props: SearchCategoryProps) {
+  const { currentCategory = '전체', categories } = props;
+  const router = useRouter();
+  const searchParam = new URLSearchParams(router?.query as Record<string, any>);
+  searchParam.delete('category');
+
+  return (
+    <CategoryList>
+      {categories.map((category) => (
+        <CategoryItem
+          key={category.category_id}
+          active={currentCategory === category.category_name}
+        >
+          <Link
+            href={`/search?${searchParam.toString()}&category=${encodeURIComponent(
+              category.category_name,
+            )}#${category.category_id}`}
+          >
+            <CategoryAnchor
+              id={category.category_id.toString()}
+            >
+              {`${category.category_name} (${category.doc_count})`}
+            </CategoryAnchor>
+          </Link>
+        </CategoryItem>
+      ))}
+    </CategoryList>
+  );
+}
+
+export default React.memo(SearchCategoryTab);

--- a/src/components/Tabs/SearchCategoryTab.tsx
+++ b/src/components/Tabs/SearchCategoryTab.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import * as SearchTypes from 'src/types/searchResults';
 import styled from '@emotion/styled';
-import { slateGray20, slateGray40 } from '@ridi/colors';
+import {
+  slateGray20, slateGray40, slateGray60, slateGray90,
+} from '@ridi/colors';
 import ScrollContainer from 'src/components/ScrollContainer';
 import { scrollBarHidden } from 'src/styles';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { orBelow } from 'src/utils/mediaQuery';
 
 interface SearchCategoryProps {
   categories: SearchTypes.Aggregation[];
@@ -18,6 +21,15 @@ const CategoryList = styled.ul`
   box-shadow: inset 0px -1px 0px ${slateGray20};
   overflow-x: auto;
   height: 45px;
+
+  ${orBelow(
+    999,
+    `
+    max-width: 100%;
+    padding-left: 16px;
+  `,
+  )};
+
   ${scrollBarHidden}
 `;
 
@@ -31,11 +43,65 @@ const CategoryItem = styled.li<{ active: boolean }>`
   box-shadow: ${(props) => (props.active ? `inset 0px -3px 0px ${slateGray40}` : 'none')};
 
   cursor: pointer;
+
+  ${orBelow(
+    999,
+    `
+    position: relative;
+    :last-of-type:after {
+      content: '';
+      display: block;
+      position: absolute;
+      right: -16px;
+      height: 100%;
+      width: 16px;
+    }
+  `,
+  )}
 `;
 
 const CategoryAnchor = styled.a`
   padding: 15px 4px;
 `;
+
+const CategoryName = styled.span<{ active: boolean }>`
+  color: ${(props) => (props.active ? slateGray90 : slateGray60)};
+  font-size: 14px;
+  font-weight: ${(props) => (props.active ? 'bold' : 500)};
+`;
+
+function Category(props: {
+  currentCategory: string;
+  category: SearchTypes.Aggregation;
+  searchParam: URLSearchParams;
+}) {
+  const { currentCategory, category, searchParam } = props;
+  const active = useMemo(() => currentCategory === category.category_name, [
+    currentCategory,
+    category.category_name,
+  ]);
+  return (
+    <CategoryItem key={category.category_id} active={active}>
+      <Link
+        href={`/search?${searchParam.toString()}&category=${encodeURIComponent(
+          category.category_name,
+        )}#${category.category_id}`}
+      >
+        <CategoryAnchor id={category.category_id.toString()}>
+          <CategoryName active={active}>{category.category_name}</CategoryName>
+          {' '}
+          <span>
+            (
+            {category.doc_count}
+            )
+          </span>
+        </CategoryAnchor>
+      </Link>
+    </CategoryItem>
+  );
+}
+
+const MemoizedCategoryItem = React.memo(Category);
 
 function SearchCategoryTab(props: SearchCategoryProps) {
   const { currentCategory = '전체', categories } = props;
@@ -46,20 +112,12 @@ function SearchCategoryTab(props: SearchCategoryProps) {
   return (
     <CategoryList>
       {categories.map((category) => (
-        <CategoryItem
+        <MemoizedCategoryItem
           key={category.category_id}
-          active={currentCategory === category.category_name}
-        >
-          <Link
-            href={`/search?${searchParam.toString()}&category=${encodeURIComponent(
-              category.category_name,
-            )}#${category.category_id}`}
-          >
-            <CategoryAnchor id={category.category_id.toString()}>
-              {`${category.category_name} (${category.doc_count})`}
-            </CategoryAnchor>
-          </Link>
-        </CategoryItem>
+          currentCategory={currentCategory}
+          category={category}
+          searchParam={searchParam}
+        />
       ))}
     </CategoryList>
   );

--- a/src/components/Tabs/SearchCategoryTab.tsx
+++ b/src/components/Tabs/SearchCategoryTab.tsx
@@ -2,9 +2,12 @@ import React, { useEffect, useMemo } from 'react';
 import * as SearchTypes from 'src/types/searchResults';
 import styled from '@emotion/styled';
 import {
-  slateGray20, slateGray40, slateGray60, slateGray90,
+  slateGray20,
+  slateGray40,
+  slateGray50,
+  slateGray60,
+  slateGray90,
 } from '@ridi/colors';
-import ScrollContainer from 'src/components/ScrollContainer';
 import { scrollBarHidden } from 'src/styles';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -70,6 +73,11 @@ const CategoryName = styled.span<{ active: boolean }>`
   font-weight: ${(props) => (props.active ? 'bold' : 500)};
 `;
 
+const CategoryCount = styled(CategoryName)`
+  opacity: 0.7;
+  color: ${(props) => (props.active ? slateGray90 : slateGray50)};
+`;
+
 function Category(props: {
   currentCategory: string;
   category: SearchTypes.Aggregation;
@@ -90,11 +98,11 @@ function Category(props: {
         <CategoryAnchor id={category.category_id.toString()}>
           <CategoryName active={active}>{category.category_name}</CategoryName>
           {' '}
-          <span>
+          <CategoryCount active={active}>
             (
             {category.doc_count}
             )
-          </span>
+          </CategoryCount>
         </CategoryAnchor>
       </Link>
     </CategoryItem>

--- a/src/components/Tabs/SearchCategoryTab.tsx
+++ b/src/components/Tabs/SearchCategoryTab.tsx
@@ -61,12 +61,12 @@ function Category(props: {
 }) {
   const { currentCategoryId, category, searchParam } = props;
   const active = currentCategoryId === category.category_id;
-  searchParam.delete('category_id');
-  searchParam.append('category_id', category.category_id.toString());
+  const copiedSearchParam = new URLSearchParams(searchParam);
+  copiedSearchParam.append('category_id', category.category_id.toString());
   return (
     <CategoryItem active={active}>
       <Link
-        href={`/search?${searchParam.toString()}#${category.category_id}`}
+        href={`/search?${copiedSearchParam.toString()}#${category.category_id}`}
       >
         <CategoryAnchor id={category.category_id.toString()}>
           <CategoryName active={active}>{category.category_name}</CategoryName>
@@ -86,7 +86,6 @@ function SearchCategoryTab(props: SearchCategoryProps) {
   const { currentCategoryId = 0, categories } = props;
   const router = useRouter();
   const searchParam = new URLSearchParams(router?.query as Record<string, any>);
-  searchParam.delete('category');
 
   return (
     <CategoryList>

--- a/src/components/Tabs/SearchCategoryTab.tsx
+++ b/src/components/Tabs/SearchCategoryTab.tsx
@@ -15,7 +15,7 @@ interface SearchCategoryProps {
 const CategoryList = styled.ul`
   display: flex;
   max-width: 952px;
-  border-bottom: 1px solid ${slateGray20};
+  box-shadow: inset 0px -1px 0px ${slateGray20};
   overflow-x: auto;
   height: 45px;
   ${scrollBarHidden}
@@ -55,9 +55,7 @@ function SearchCategoryTab(props: SearchCategoryProps) {
               category.category_name,
             )}#${category.category_id}`}
           >
-            <CategoryAnchor
-              id={category.category_id.toString()}
-            >
+            <CategoryAnchor id={category.category_id.toString()}>
               {`${category.category_name} (${category.doc_count})`}
             </CategoryAnchor>
           </Link>

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,4 +1,5 @@
 import MainTab from './MainTab';
 import GenreTab from './GenreTab';
+import SearchCategoryTab from './SearchCategoryTab';
 
-export { GenreTab, MainTab };
+export { GenreTab, MainTab, SearchCategoryTab };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -19,6 +19,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from 'src/store/config';
 import { getEscapedNode } from 'src/utils/highlight';
 import { computeSearchBookTitle } from 'src/utils/bookTitleGenerator';
+import ScrollContainer from 'src/components/ScrollContainer';
 
 interface SearchProps {
   q?: string;
@@ -31,6 +32,13 @@ interface SearchProps {
 const SearchResultSection = styled.section`
   max-width: 952px;
   margin: 0 auto;
+
+  ${orBelow(
+    999,
+    `
+    max-width: 100%;
+  `,
+  )};
 `;
 
 const SearchTitle = styled.h3`
@@ -83,6 +91,19 @@ const Arrow = styled(ArrowBoldH, {
   transform: rotate(${(props) => (props.isRotate ? '180deg' : '0deg')});
 `;
 
+function Author(props: { author: SearchTypes.Author; q: string; show: boolean }) {
+  const { author, q, show } = props;
+  return (
+    <AuthorItem show={show}>
+      <a href={`/author/${author.id}?_s=search&_q=${encodeURIComponent(q)}`}>
+        <AuthorInfo author={author} />
+      </a>
+    </AuthorItem>
+  );
+}
+
+const MemoizedAuthor = React.memo(Author);
+
 function Authors(props: { author: SearchTypes.AuthorResult; q: string }) {
   const {
     author: { authors, total },
@@ -95,18 +116,10 @@ function Authors(props: { author: SearchTypes.AuthorResult; q: string }) {
   return (
     <AuthorList>
       {authorsPreview.map((author) => (
-        <AuthorItem key={author.id} show>
-          <a href={`/author/${author.id}?_s=search&_q=${encodeURIComponent(q)}`}>
-            <AuthorInfo author={author} />
-          </a>
-        </AuthorItem>
+        <MemoizedAuthor show key={author.id} author={author} q={q} />
       ))}
       {restAuthors.map((author) => (
-        <AuthorItem key={author.id} show={isShowMore}>
-          <a href={`/author/${author.id}?_s=search&_q=${encodeURIComponent(q)}`}>
-            <AuthorInfo author={author} />
-          </a>
-        </AuthorItem>
+        <MemoizedAuthor show={isShowMore} key={author.id} author={author} q={q} />
       ))}
       {authors.length > DEFAULT_SHOW_AUTHOR_COUNT && (
         <ShowMoreAuthor onClick={() => setShowMore((current) => !current)}>
@@ -124,6 +137,8 @@ function Authors(props: { author: SearchTypes.AuthorResult; q: string }) {
     </AuthorList>
   );
 }
+
+const MemoizedAuthors = React.memo(Authors);
 
 function SearchBooks(props: { books: SearchTypes.SearchBookDetail[] }) {
   const { books } = props;
@@ -180,7 +195,7 @@ function SearchPage(props: SearchProps) {
                 }
               </TotalAuthor>
             </SearchTitle>
-            <Authors author={author} q={q || ''} />
+            <MemoizedAuthors author={author} q={q || ''} />
           </>
         )
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -256,7 +256,7 @@ SearchPage.getInitialProps = async (props: ConnectedInitializeProps) => {
   searchUrl.searchParams.append('where', 'book');
   searchUrl.searchParams.append('what', 'base');
   searchUrl.searchParams.append('keyword', searchKeyword as string);
-  if (query.category_id && !isNaN(parseInt(query.category_id as string, 10))) {
+  if (/^\d+$/.test(String(query.category_id))) {
     searchUrl.searchParams.delete('category_id');
     searchUrl.searchParams.append('category_id', query.category_id.toString());
   }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -11,7 +11,7 @@ import { BreakPoint, orBelow } from 'src/utils/mediaQuery';
 import isPropValid from '@emotion/is-prop-valid';
 import { SearchCategoryTab } from 'src/components/Tabs';
 import { css } from '@emotion/core';
-import { SearchResult } from 'src/types/searchResults';
+import { Aggregation, SearchResult } from 'src/types/searchResults';
 import { useCallback, useEffect } from 'react';
 import sentry from 'src/utils/sentry';
 import { useEventTracker } from 'src/hooks/useEventTracker';

--- a/src/svgs/ArrowBoldV.svg
+++ b/src/svgs/ArrowBoldV.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="12" viewBox="0 0 10 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.7998 1.272L6.7248 6L1.7998 10.728L3.1248 12L9.3748 6L3.1248 0L1.7998 1.272Z" fill="#B8BFC4"/>
+</svg>

--- a/src/tests/pages/search/Index.spec.tsx
+++ b/src/tests/pages/search/Index.spec.tsx
@@ -90,12 +90,14 @@ describe('Search Page Test', () => {
 
   it('should be render category tab', () => {
     const { getByText } = render(
-      <Index
-        q={'유유'}
-        book={fixture.book}
-        author={fixture.author}
-        categories={fixture.book.aggregations}
-      />,
+      <Provider store={store}>
+        <Index
+          q={'유유'}
+          book={fixture.book}
+          author={fixture.author}
+          categories={fixture.book.aggregations}
+        />
+      </Provider>,
     );
     const container = getByText(/성공\/삶의자세/);
 

--- a/src/tests/pages/search/Index.spec.tsx
+++ b/src/tests/pages/search/Index.spec.tsx
@@ -87,4 +87,18 @@ describe('Search Page Test', () => {
 
   // Todo 저자가 없을 경우, 도서가 없을 경우
   it.todo('should be render empty state');
+
+  it('should be render category tab', () => {
+    const { getByText } = render(
+      <Index
+        q={'유유'}
+        book={fixture.book}
+        author={fixture.author}
+        categories={fixture.book.aggregations}
+      />,
+    );
+    const container = getByText(/성공\/삶의자세/);
+
+    expect(container).toHaveTextContent('성공/삶의자세');
+  })
 });

--- a/src/tests/pages/search/Index.spec.tsx
+++ b/src/tests/pages/search/Index.spec.tsx
@@ -43,7 +43,7 @@ describe('Search Page Test', () => {
         query: { q: '유유' },
       });
       // FIXME client side fetch 아직 없음
-      expect(props.book?.total).toBeUndefined();
+      expect(props.book.total).toEqual(147);
     });
   });
 


### PR DESCRIPTION
### 태스크
https://app.asana.com/0/1168838717676674/1166368617863802
검색 페이지 첫 진입(SSR) 이후부터는 `CSR` 로 표시합니다. 
- [x] 컴포넌트 구현
- [x] Client Side Fetch
- [x] 스타일링
  - [ ] ScrollContainer 안에 Custom Arrow 를 넣을 수 있는 기능 추가 -> 별도의 PR 
![image](https://user-images.githubusercontent.com/45959991/79202914-3db88e00-7e75-11ea-9ced-ca59097e2a14.png)
*SVG 원본이 다름*


~~- 중복되는 카테고리 이름 Merge 하여 표시~~
~~**논의 타래**~~
~~https://rididev.slack.com/archives/CF61X1FHC/p1586760342098700~~

서점 정기 회의 때 UI 변경 사항이 있을거라고 재논의 하였음.

![image](https://user-images.githubusercontent.com/45959991/79203288-c800f200-7e75-11ea-84ec-c80361a29ae0.png)
