### PR TITLE
Fix: c3703e5da767449bfb8749ccaba537b7e4abe21a

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
             echo "export TITLE='$(echo "$TITLE")'" >> $BASH_ENV
       - run:
           command: |
-            export LAST_RELEASE=$([ "$CIRCLE_BRANCH" = master ] && echo "HEAD^1" || echo "`git for-each-ref --count=2 --sort=-committerdate --format='%(objectname)' refs/remotes/origin/release/ | tail -n1`")
+            export LAST_RELEASE=$([ "$CIRCLE_BRANCH" = master ] && echo "HEAD^1" || echo "`git for-each-ref --count=2 --sort=committerdate --format='%(objectname)' refs/remotes/origin/release/ | tail -n1`")
             export MESSAGE="`git show -s --format=%b $CIRCLE_SHA1 | sed "s/'/\\\\\'/g"`"
             export MESSAGE="$MESSAGE\n\n$(git log $LAST_RELEASE..$CIRCLE_SHA1 --no-merges --pretty=format:'* `%h` %s')"
             echo "export MESSAGE='$(echo "$MESSAGE")'" >> $BASH_ENV


### PR DESCRIPTION
release branch 가 2개 이상인 경우에 대응하기 위해서 수정한 https://github.com/ridi/books-frontend/commit/c3703e5da767449bfb8749ccaba537b7e4abe21a 커밋에서 정렬을 역순으로 수정합니다.