### PR TITLE
스크롤 컨테이너에 불필요한 수직 스크롤이 나타나는 걸 막습니다.

### DIFF
--- a/src/components/ScrollContainer.tsx
+++ b/src/components/ScrollContainer.tsx
@@ -13,8 +13,9 @@ const ControllerContainer = styled.div`
 
 const SlidingContainer = styled.div`
   display: flex;
-  flex-wrap: none;
-  overflow: auto;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
   ${scrollBarHidden}
 `;
 


### PR DESCRIPTION
### 태스크
https://app.asana.com/0/1170943144130890/1171189827082006

- flex-wrap: none; -> flex-wrap: nowrap;
- overflow-x: auto;
- overflow-y: hidden;
