### PR TITLE
BookMeta에서 showRating의 기능을 ratingInfo와 합침

### DIFF
--- a/src/components/BookMeta/index.tsx
+++ b/src/components/BookMeta/index.tsx
@@ -16,7 +16,6 @@ const TagWrapper = styled.div`
 interface BookMetaProps {
   book: BookApi.Book;
   titleLineClamp?: number;
-  showRating: boolean;
   showSomeDeal?: boolean;
   isAIRecommendation?: boolean;
   showTag: boolean;
@@ -37,7 +36,6 @@ export default function BookMeta(props: BookMetaProps) {
     },
     showTag,
     showSomeDeal,
-    showRating,
     ratingInfo,
     titleLineClamp,
     className,
@@ -50,7 +48,7 @@ export default function BookMeta(props: BookMetaProps) {
       width={width}
       className={className}
     >
-      {showRating && ratingInfo && (
+      {ratingInfo && (
         <span>
           <StarRating
             totalReviewer={ratingInfo.buyer_rating_count}

--- a/src/components/BookSections/RankingBook/RankingBookList.tsx
+++ b/src/components/BookSections/RankingBook/RankingBookList.tsx
@@ -246,13 +246,12 @@ const ItemList: React.FC<ItemListProps> = (props) => {
                 {book.detail && (
                   <BookMeta
                     book={book.detail}
-                    showRating={props.type === 'big' || !!(book as MdBook).rating}
                     titleLineClamp={props.type === 'small' ? 1 : 2}
                     isAIRecommendation={false}
                     showSomeDeal={showSomeDeal}
                     showTag={false}
                     width={props.type === 'big' ? '177px' : null}
-                    ratingInfo={(book as MdBook).rating}
+                    ratingInfo={props.type === 'big' ? (book as MdBook).rating : undefined}
                   />
                 )}
               </div>

--- a/src/components/BookSections/SelectionBook/SelectionBookItem.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookItem.tsx
@@ -32,12 +32,14 @@ const SelectionBookItem: React.FC<Props> = (props) => {
   const {
     book,
     genre,
-    type,
     slug,
     order,
     className,
   } = props;
   const { b_id: bId, detail } = book;
+  const ratingInfo = props.type === DisplayType.HomeMdSelection
+    ? props.book.rating
+    : undefined;
 
   const [tracker] = useEventTracker();
 
@@ -59,8 +61,7 @@ const SelectionBookItem: React.FC<Props> = (props) => {
         <BookMeta
           showTag={['bl', 'bl-serial'].includes(genre)}
           book={detail}
-          showRating={type === DisplayType.HomeMdSelection}
-          ratingInfo={(book as MdBook).rating}
+          ratingInfo={ratingInfo}
         />
       )}
     </PortraitBook>

--- a/src/components/MultipleLineBooks/MultipleLineBooks.tsx
+++ b/src/components/MultipleLineBooks/MultipleLineBooks.tsx
@@ -188,7 +188,6 @@ const MultipleLineBookItem: React.FC<MultipleLineBookItemProps> = React.memo((pr
           book={item.detail}
           showTag={['bl', 'bl-serial'].includes(genre)}
           css={bookMetaWrapperStyle}
-          showRating
           isAIRecommendation={false}
         />
       )}


### PR DESCRIPTION
`showRating`을 없애고, `ratingInfo`가 널 값이면 별점이 보이지 않게 처리했습니다.