### PR TITLE
Fix/category scroll

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -101,7 +101,7 @@ const MAX_PAGE = 400;
 function getQueryParamsToString(searchParam: URLSearchParams, page: string) {
   const params = new URLSearchParams(searchParam);
   params.set('page', page);
-  return `${params.toString()}`;
+  return params.toString();
 }
 
 export function Pagination(props: PaginationProps) {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -46,7 +46,7 @@ const PageButton = styled.button`
 
 const Pages = styled.ul`
   display: flex;
-  
+
   > * + * {
     margin-left: -1px;
   }
@@ -101,7 +101,7 @@ const MAX_PAGE = 400;
 function getQueryParamsToString(searchParam: URLSearchParams, page: string) {
   const params = new URLSearchParams(searchParam);
   params.set('page', page);
-  return `${params.toString()}#${params.get('categoryId') || ''}`;
+  return `${params.toString()}`;
 }
 
 export function Pagination(props: PaginationProps) {

--- a/src/components/Tabs/SearchCategoryTab.tsx
+++ b/src/components/Tabs/SearchCategoryTab.tsx
@@ -38,6 +38,9 @@ const CategoryItem = styled.li<{ active: boolean }>`
 
 const CategoryAnchor = styled.a`
   padding: 15px 4px;
+  :active {
+    background: rgba(0, 0, 0, 0.05);
+  }
 `;
 
 const CategoryName = styled.span<{ active: boolean }>`

--- a/src/components/Tabs/SearchCategoryTab.tsx
+++ b/src/components/Tabs/SearchCategoryTab.tsx
@@ -90,7 +90,7 @@ function SearchCategoryTab(props: SearchCategoryProps) {
   const searchParam = new URLSearchParams(router?.query as Record<string, string>);
   useEffect(() => {
     if (ref.current) {
-      const activeItem = Array.from(ref.current.querySelectorAll('li')).find((item) => item.dataset.isActive === 'true');
+      const activeItem: HTMLLIElement | null = ref.current.querySelector('li[data-is-active=true]');
       if (activeItem) {
         const { offsetLeft = 0 } = activeItem;
         const scrollableItem = findNearestOverflowElement(activeItem, 3);

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -104,3 +104,23 @@ export const getMaxDiscountPercentage = (book: BookApi.Book | null) => {
   }
   return 0;
 };
+
+/**
+ * overflow-x: auto 를 가진 가까운 부모 엘리먼트 찾기
+ *
+ * @param {HTMLElement} element 시작 엘리먼트
+ * @param {number} findDepth 찾는 깊이
+ * @returns HTMLElement | null
+ */
+export function findNearestOverflowElement(element: HTMLElement, findDepth = 5): HTMLElement | null {
+  if (findDepth === 0) {
+    return null;
+  }
+  if (element.parentElement) {
+    if (window.getComputedStyle(element.parentElement).overflowX === 'auto') {
+      return element.parentElement;
+    }
+    return findNearestOverflowElement(element.parentElement, findDepth - 1);
+  }
+  return null;
+}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -108,9 +108,9 @@ export const getMaxDiscountPercentage = (book: BookApi.Book | null) => {
 /**
  * overflow-x: auto 를 가진 가까운 부모 엘리먼트 찾기
  *
- * @param {HTMLElement} element 시작 엘리먼트
- * @param {number} findDepth 찾는 깊이
- * @returns HTMLElement | null
+ * @param element 시작 엘리먼트
+ * @param findDepth 찾는 깊이
+ * @returns 찾아 낸 부모엘리먼트 혹은 null
  */
 export function findNearestOverflowElement(element: HTMLElement, findDepth = 5): HTMLElement | null {
   if (findDepth === 0) {


### PR DESCRIPTION
앵커 스크롤을 제거하고 스크립트로 스크롤 위치를 찾아 카테고리 탭을 이동합니다.
 
- [x] [카테고리 탭 > 2차 카테고리 선택 시 화면이 위로 올라감](https://app.asana.com/0/947013990327604/1174634480215380)
- [x] 탭 active 컬러 추가
