### PR TITLE
디자인 QA 2차 반영

### DIFF
--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -35,13 +35,16 @@ const SearchBookTitle = styled.h3`
   margin-bottom: 4px;
   font-size: 14px;
   font-weight: normal;
+  line-height: 1.36em;
+  a:active {
+    text-decoration-line: underline;
+  }
   ${lineClamp(2)}
-  ${orBelow(BreakPoint.LG, 'line-height: 1.36em;')}
 `;
 
 const SearchBookMetaList = styled.ul`
   display: flex;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
   ${orBelow(BreakPoint.LG, 'flex-direction: column; margin-bottom: 4px;')};
 `;
 
@@ -113,8 +116,11 @@ const fieldStyles = {
 const SearchBookMetaField = styled.span<{
   type: 'author' | 'normal' | 'rating' | 'rating_count';
 }>`
+  line-height: 1.36em;
+  a:active {
+    text-decoration-line: underline;
+  }
   ${(props) => fieldStyles[props.type]}
-  ${orBelow(BreakPoint.LG, 'line-height: 1.36em;')}
 `;
 
 const ThumbnailAnchor = styled.a`
@@ -124,7 +130,7 @@ const ThumbnailAnchor = styled.a`
 const BookDesc = styled.p`
   max-width: 836px;
   font-size: 13px;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
   color: ${slateGray60};
   line-height: 1.4em;
   word-break: keep-all;
@@ -151,7 +157,7 @@ const priceBase = css`
   line-height: 18px;
 `;
 const PriceTitle = styled.dt`
-  margin-right: 2px;
+  margin-right: 4px;
   color: ${slateGray60};
   ${priceBase}
 `;
@@ -178,6 +184,9 @@ const SearchBookMetaWrapper = styled.div`
    display: flex;
    flex-direction: column;
    margin-left: 16px;
+   > dl {
+    margin-bottom: 4px;
+  }
    width: 100%;
 `;
 

--- a/src/components/Tabs/SearchCategoryTab.tsx
+++ b/src/components/Tabs/SearchCategoryTab.tsx
@@ -22,7 +22,7 @@ const CategoryList = styled.ul`
   display: flex;
   box-shadow: inset 0px -1px 0px ${slateGray20};
   height: 45px;
-  ${orBelow(BreakPoint.MD, 'padding-left: 16px; padding-right: 16px;')};
+  ${orBelow(BreakPoint.LG, 'padding-left: 16px; padding-right: 16px;')};
 `;
 
 const CategoryItem = styled.li<{ active: boolean }>`

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -198,8 +198,8 @@ const NoResult = styled.div`
     flex: none;
     margin-bottom: 16px;
   }
-  padding: 200px 0 360px 0;
-  ${orBelow(BreakPoint.MD, 'padding: 80px 0 240px 0;')}
+  padding: 200px 0 360px;
+  ${orBelow(BreakPoint.MD, 'padding: 80px 0 240px;')}
 `;
 
 const NoResultLens = styled(Lens)`

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -49,7 +49,7 @@ const SearchResultSection = styled.section`
   min-height: 620px;
   margin: 0 auto;
   padding-top: 8px;
-  ${orBelow(BreakPoint.MD, 'max-width: 100%;')}
+  ${orBelow(BreakPoint.LG, 'max-width: 100%;')}
 `;
 
 const SearchTitle = styled.h2`
@@ -74,11 +74,13 @@ const AuthorItem = styled.li<{ show: boolean }>`
   padding: 12px 0;
   display: ${(props) => (props.show ? 'flex' : 'none')};
   align-items: center;
+  :active {
+    background: rgba(0, 0, 0, 0.05);
+  }
 `;
 
 const AuthorList = styled.ul`
   margin-bottom: 16px;
-  ${orBelow(BreakPoint.LG, 'padding: 0 16px;')}
 `;
 
 const ShowMoreAuthor = styled.li`
@@ -89,6 +91,15 @@ const ShowMoreAuthor = styled.li`
   display: flex;
   cursor: pointer;
   align-items: center;
+  :active {
+    background: rgba(0, 0, 0, 0.05);
+  }
+  ${orBelow(BreakPoint.LG, 'padding: 12px 16px;')}
+`;
+
+const AuthorAnchor = styled.a`
+  width: 100%;
+  ${orBelow(BreakPoint.LG, 'padding: 0px 16px;')}
 `;
 
 const MAXIMUM_AUTHOR = 30;
@@ -109,9 +120,9 @@ function Author(props: { author: SearchTypes.Author; q: string; show: boolean })
   const { author, q, show } = props;
   return (
     <AuthorItem show={show}>
-      <a href={`/author/${author.id}?_s=search&_q=${encodeURIComponent(q)}`}>
+      <AuthorAnchor href={`/author/${author.id}?_s=search&_q=${encodeURIComponent(q)}`}>
         <AuthorInfo author={author} />
-      </a>
+      </AuthorAnchor>
     </AuthorItem>
   );
 }
@@ -159,11 +170,10 @@ const SearchBookList = styled.ul`
 
 const SearchBookItem = styled.li`
   display: flex;
-  margin: 0 4px;
   padding: 20px 0;
   border-bottom: 1px solid ${slateGray20};
   align-items: flex-start;
-  ${orBelow(BreakPoint.LG, 'margin: 0 20px;')};
+  ${orBelow(BreakPoint.LG, 'margin: 0 16px;')};
 `;
 
 const Filters = styled.div`
@@ -188,9 +198,8 @@ const NoResult = styled.div`
     flex: none;
     margin-bottom: 16px;
   }
-  margin-top: 202px;
-  margin-bottom: 232px;
-  ${orBelow(BreakPoint.LG, 'margin-top: 102px; margin-bottom: 132px')}
+  padding: 200px 0 360px 0;
+  ${orBelow(BreakPoint.MD, 'padding: 80px 0 240px 0;')}
 `;
 
 const NoResultLens = styled(Lens)`
@@ -298,7 +307,7 @@ function SearchPage(props: SearchProps) {
         ) : (
           <NoResult>
             <NoResultLens />
-            <NoResultText>{`‘${q}’에 대한 검색 결과가 없습니다.`}</NoResultText>
+            <NoResultText>{`‘${q}’에 대한 도서 검색 결과가 없습니다.`}</NoResultText>
             <SuggestButton href="https://help.ridibooks.com/hc/ko/requests/new?ticket_form_id=664028" rel="noreferrer nooppener" target="_blank">도서 제안하기</SuggestButton>
           </NoResult>
         )}


### PR DESCRIPTION
- [x] [북 컴포넌트 좌우 여백](https://app.asana.com/0/1175078605752106/1175108403511952)
- [x] [카테고리 탭 > 834px~999px 사이 좌우 여백이 사라지고 양 옆에 붙음](https://app.asana.com/0/1175078605752106/1175108403511955)
- [x] [데스크톱 북 컴포넌트 > 모바일 북 컴포넌트와 같이 line-height 1.36em 추가 필요](https://app.asana.com/0/1175078605752106/1175108403511964)
- [x] [데스크톱 북 컴포넌트 > 책 정보 위 아래 여백 8px 👉6px로 변경](https://app.asana.com/0/1175078605752106/1175108403511965)
- [x] [북 컴포넌트 > 가격 > 대여, 구매 옆 여백 2px 👉4px로 변경 ](https://app.asana.com/0/1175078605752106/1175108403511966)
- [x] [대여와 구매 사이 간격 4px 추가 필요](https://app.asana.com/0/1175078605752106/1175108403511968)
- [x] [empty state > 중앙 메시지 아래 위 여백](https://app.asana.com/0/1175078605752106/1175309255171741)
- [x] [empty state 메시지 수정](https://app.asana.com/0/947013990327604/1175514925875693)