### PR TITLE
computeBookTitle 호출처 줄임

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,8 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|less)$': 'identity-obj-proxy',
     '\\.(jpg|png|webp|ico|ttf|otf|woff|woff2)$': '<rootDir>/src/tests/__mocks__/fileMock.ts',
-    '\\.svg': '<rootDir>/src/tests/__mocks__/svgrMock.tsx',
+    'assets/.+\\.svg$': '<rootDir>/src/tests/__mocks__/fileMock.ts',
+    '\\.svg$': '<rootDir>/src/tests/__mocks__/svgrMock.tsx',
   },
   coveragePathIgnorePatterns: ['/node_modules/', '/cypress/'],
   testPathIgnorePatterns: ['/node_modules/', '/cypress/'],

--- a/src/components/Book/PortraitBook.tsx
+++ b/src/components/Book/PortraitBook.tsx
@@ -44,7 +44,6 @@ interface Props {
   onClick?(): void;
   className?: string;
   children?: React.ReactNode;
-  title: string;
 }
 
 const StyledAnchor = styled.a`
@@ -60,7 +59,6 @@ export default function PortraitBook(props: Props) {
     disabled,
     onClick,
     className,
-    title,
     children,
   } = props;
   const href = `/books/${bId}`;
@@ -73,7 +71,6 @@ export default function PortraitBook(props: Props) {
             order={index}
             genre={genre}
             slug={slug}
-            title={title}
             sizes="(max-width: 999px) 100px, 140px"
           />
         </StyledThumbnailWrapper>

--- a/src/components/Book/ThumbnailWithBadge.tsx
+++ b/src/components/Book/ThumbnailWithBadge.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useBookSelector } from 'src/hooks/useBookDetailSelector';
+import { computeBookTitle } from 'src/utils/bookTitleGenerator';
 import { getMaxDiscountPercentage } from 'src/utils/common';
 import { getThumbnailIdFromBookDetail } from 'src/utils/books';
 
@@ -18,8 +19,8 @@ interface Props {
   slug: string;
   sizes: string;
   className?: string;
-  title: string;
   onlyAdultBadge?: boolean;
+  title?: string;
 }
 
 export default function ThumbnailWithBadge(props: Props) {
@@ -30,10 +31,10 @@ export default function ThumbnailWithBadge(props: Props) {
     slug,
     sizes,
     className,
-    title,
     onlyAdultBadge,
   } = props;
   const bookDetail = useBookSelector(bId);
+  const title = props.title || computeBookTitle(bookDetail);
   const singlePriceInfo = bookDetail?.price_info;
   const seriesPriceInfo = bookDetail?.series?.price_info;
   return (

--- a/src/components/BookSections/RankingBook/RankingBookList.tsx
+++ b/src/components/BookSections/RankingBook/RankingBookList.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 
-import { computeBookTitle } from 'src/utils/bookTitleGenerator';
 import { createTimeLabel } from 'src/utils/dateTime';
 import { BreakPoint, orBelow } from 'src/utils/mediaQuery';
 import {
@@ -11,7 +10,6 @@ import BookMeta from 'src/components/BookMeta';
 import ThumbnailWithBadge from 'src/components/Book/ThumbnailWithBadge';
 import ScrollContainer from 'src/components/ScrollContainer';
 import { CLOCK_ICON_URL } from 'src/constants/icons';
-import { useBookSelector } from 'src/hooks/useBookDetailSelector';
 
 import { SectionTitle, SectionTitleLink } from '../SectionTitle';
 
@@ -145,12 +143,6 @@ function RankingBook({
   showSomeDeal,
   rating,
 }: Omit<ItemListProps, 'books'> & {bId: string; order: number; rating?: StarRating}) {
-  const book = useBookSelector(bId);
-  if (book == null || book.is_deleted) {
-    return null;
-  }
-
-  const title = computeBookTitle(book);
   return (
     // auto-flow 안 되는 IE11을 위한 땜빵
     <RankingBookItem
@@ -169,7 +161,6 @@ function RankingBook({
           slug={slug}
           sizes={type === 'big' ? '80px' : '50px'}
           type={type}
-          title={title}
           onlyAdultBadge={type !== 'big'}
         />
       </ThumbnailAnchor>

--- a/src/components/BookSections/SelectionBook/SelectionBookItem.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookItem.tsx
@@ -12,8 +12,6 @@ import {
   BookItem,
 } from 'src/types/sections';
 import PortraitBook from 'src/components/Book/PortraitBook';
-import { computeBookTitle } from 'src/utils/bookTitleGenerator';
-import { useBookSelector } from 'src/hooks/useBookDetailSelector';
 
 const RecommendButton = styled.button<{ fetching?: boolean }>`
   width: 55px;
@@ -96,11 +94,6 @@ const SelectionBookItem: React.FC<Props> = (props) => {
   const handleClick = useCallback(() => {
     sendClickEvent(tracker, book, slug, order);
   }, [tracker, book, slug, order]);
-  const bookDetail = useBookSelector(book.b_id);
-  if (bookDetail == null || bookDetail.is_deleted) {
-    return null;
-  }
-  const title = computeBookTitle(bookDetail);
   return (
     <PortraitBook
       bId={book.b_id}
@@ -110,7 +103,6 @@ const SelectionBookItem: React.FC<Props> = (props) => {
       disabled={localExcluded}
       onClick={handleClick}
       className={className}
-      title={title}
     >
       <BookMeta
         showTag={['bl', 'bl-serial'].includes(genre)}

--- a/src/components/RecommendedBook/RecommendedBookItem.tsx
+++ b/src/components/RecommendedBook/RecommendedBookItem.tsx
@@ -4,10 +4,8 @@ import styled from '@emotion/styled';
 import PortraitBook from 'src/components/Book/PortraitBook';
 import { HotRelease, TodayRecommendation } from 'src/types/sections';
 import { newlineToReactNode } from 'src/utils/highlight';
-import { computeBookTitle } from 'src/utils/bookTitleGenerator';
 import { BreakPoint } from 'src/utils/mediaQuery';
 
-import { useBookSelector } from 'src/hooks/useBookDetailSelector';
 import BookMeta from './BookMeta';
 
 interface CommonProps {
@@ -58,8 +56,6 @@ function RecommendedBookItem(props: Props) {
     className,
     book,
   } = props;
-  const bookDetail = useBookSelector(book.b_id);
-  const title = computeBookTitle(bookDetail);
   return (
     <PortraitBook
       bId={props.book.b_id}
@@ -67,11 +63,10 @@ function RecommendedBookItem(props: Props) {
       genre={genre}
       slug={slug}
       className={className}
-      title={title}
     >
       {/* Todo show sentence */}
-      {bookDetail && props.type === 'HotRelease' && <BookMeta bId={book.b_id} />}
-      {bookDetail && props.type === 'TodayRecommendation' && (
+      {props.type === 'HotRelease' && <BookMeta bId={book.b_id} />}
+      {props.type === 'TodayRecommendation' && (
         <RecommendationText bg={theme}>
           {newlineToReactNode(props.book.sentence)}
         </RecommendationText>

--- a/src/tests/__mocks__/fileMock.ts
+++ b/src/tests/__mocks__/fileMock.ts
@@ -1,1 +1,1 @@
-module.exports = 'test-file-stub';
+export default 'test-file-stub';

--- a/src/tests/components/MultipleLineBook/MultipleLineBookComponent.spec.tsx
+++ b/src/tests/components/MultipleLineBook/MultipleLineBookComponent.spec.tsx
@@ -22,7 +22,6 @@ const store = makeStore(
     account: {
       loggedUser: null,
     },
-    router: undefined,
     categories: {
       items: {},
       isFetching: false,


### PR DESCRIPTION
svg를 로드할 때 무조건 svgr mock이 불러오는 현상을 같이 수정했습니다. 이제 `toString`을 매번 부를 필요가 없습니다.
