### PR TITLE
썸네일, 대여 배지 표시 오류 수정, 렌트 가격 일부 조정

### DIFF
--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -265,7 +265,8 @@ function PriceInfo(props: {
         {rent && (
           <PriceLabel
             title="대여"
-            price={rent.price}
+            // https://rididev.slack.com/archives/CE55MTQH2/p1589365195037000
+            price={rent.price === 0 ? rent.regular_price : rent.price}
             discount={rent.discount_percentage}
           />
         )}

--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -265,7 +265,7 @@ function PriceInfo(props: {
         {rent && (
           <PriceLabel
             title="대여"
-            price={rent.regular_price}
+            price={rent.price}
             discount={rent.discount_percentage}
           />
         )}
@@ -285,16 +285,6 @@ function PriceInfo(props: {
 interface SearchLandscapeBookProps {
   item: SearchTypes.SearchBookDetail;
   title: string;
-}
-
-function getLastVolumeId(item: SearchTypes.SearchBookDetail) {
-  if (item.is_series_complete || item.book_count === 1) {
-    return item.b_id;
-  }
-  if (item.opened_last_volume_id.length > 0) {
-    return item.opened_last_volume_id;
-  }
-  return item.b_id;
 }
 
 type RenderCategoryNameProps = Pick<
@@ -356,7 +346,6 @@ const SkeletonBar = styled.div<{width: string}>`
 
 export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
   const { item, title } = props;
-  const thumbnailId = getLastVolumeId(item);
   const book = useBookSelector(item.b_id);
   if (book === null) {
     return (
@@ -372,7 +361,6 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
   if (book.is_deleted) {
     return null;
   }
-
   const categoryInfo = {
     category: item.category,
     category_name: item.category_name,
@@ -395,7 +383,7 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
     <>
       <ThumbnailAnchor href={`/books/${item.b_id}`}>
         <StyledThumbnailWithBadge
-          bId={thumbnailId}
+          bId={item.b_id}
           genre={genres[0] ?? ''}
           slug="search-result"
           sizes="(min-width: 999px) 100px, 80px"

--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -192,7 +192,7 @@ const SearchBookMetaWrapper = styled.div`
 
 function PriceLabel(props: { title: string; price: number; discount?: number }) {
   const { title, price, discount = 0 } = props;
-  const realPrice = Math.ceil(price - price * (discount / 100)).toLocaleString('ko-KR');
+  const realPrice = (price - Math.ceil(price * (discount / 100))).toLocaleString('ko-KR');
   return (
     <PriceItem>
       <PriceTitle>{title}</PriceTitle>
@@ -231,7 +231,7 @@ function PriceInfo(props: {
   props.seriesPriceInfo.forEach((info) => {
     seriesPriceInfo[info.type] = info;
   });
-  if (seriesPriceInfo.rent || seriesPriceInfo.normal) {
+  if (book?.series?.property.is_serial && (seriesPriceInfo.rent || seriesPriceInfo.normal)) {
     return (
       <>
         {seriesPriceInfo.rent && !book?.property.is_trial && (
@@ -459,12 +459,12 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
               <RenderCategoryName {...categoryInfo} />
             </SearchBookMetaField>
           </SearchBookMetaItem>
-          {item.book_count > 1 && (
+          {item.book_count > 1 && book?.categories[0].is_series_category && (
             <SearchBookMetaItem>
               <SearchBookMetaField type="normal">
                 {`총 ${item.book_count}권`}
               </SearchBookMetaField>
-              {item.series_prices_info.length > 0 && item.is_series_complete && (
+              {item.series_prices_info.length > 0 && book.series?.property.is_serial_complete && (
                 <SeriesCompleted>완결</SeriesCompleted>
               )}
             </SearchBookMetaItem>

--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -220,7 +220,7 @@ function PriceLabel(props: { title: string; price: number; discount?: number }) 
 
 function PriceInfo(props: {
   seriesPriceInfo: SearchTypes.SeriesPriceInfo[];
-  book: BookApi.ClientBook | null;
+  book: BookApi.ClientBook;
   isTrial: boolean;
 }) {
   if (!props.book) {
@@ -231,10 +231,10 @@ function PriceInfo(props: {
   props.seriesPriceInfo.forEach((info) => {
     seriesPriceInfo[info.type] = info;
   });
-  if (book?.series?.property.is_serial && (seriesPriceInfo.rent || seriesPriceInfo.normal)) {
+  if (book.series?.property.is_serial && (seriesPriceInfo.rent || seriesPriceInfo.normal)) {
     return (
       <>
-        {seriesPriceInfo.rent && !book?.property.is_trial && (
+        {seriesPriceInfo.rent && !book.property.is_trial && (
           <PriceLabel
             title="대여"
             price={
@@ -255,10 +255,10 @@ function PriceInfo(props: {
   }
 
   // 체험판
-  if (!book?.price_info && book?.property.is_trial) {
+  if (!book.price_info && book.property.is_trial) {
     return <PriceLabel title="구매" price={0} discount={0} />;
   }
-  if (book?.price_info) {
+  if (book.price_info) {
     const { buy = null, rent = null } = book.price_info;
     return (
       <>
@@ -370,10 +370,10 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
     parent_category_name: item.parent_category_name,
     parent_category_name2: item.parent_category_name2,
   };
-  const rawDesc = book?.clientBookFields?.desc;
+  const rawDesc = book.clientBookFields?.desc;
   const clearDesc = rawDesc ? constructSearchDesc(rawDesc) : '';
   // 대여 배지 표기 여부가 장르에 따라 바뀌기 때문에 장르를 모아둠
-  const genres = book?.categories.map((category) => category.sub_genre) ?? ['general'];
+  const genres = book.categories.map((category) => category.sub_genre) ?? ['general'];
   let translator: AuthorsInfo | undefined;
   item.authors_info.forEach((author) => {
     if (author.role === AuthorRole.TRANSLATOR) {
@@ -448,7 +448,7 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
               <RenderCategoryName {...categoryInfo} />
             </SearchBookMetaField>
           </SearchBookMetaItem>
-          {item.book_count > 1 && book?.categories[0].is_series_category && (
+          {item.book_count > 1 && book.categories[0].is_series_category && (
             <SearchBookMetaItem>
               <SearchBookMetaField type="normal">
                 {`총 ${item.book_count}권`}
@@ -467,7 +467,7 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
         <PriceInfo
           seriesPriceInfo={item.series_prices_info}
           book={book}
-          isTrial={book?.property.is_trial || false}
+          isTrial={book.property.is_trial || false}
         />
       </SearchBookMetaWrapper>
     </>

--- a/src/components/Book/ThumbnailWithBadge.tsx
+++ b/src/components/Book/ThumbnailWithBadge.tsx
@@ -54,7 +54,7 @@ export default function ThumbnailWithBadge(props: Props) {
             <BookBadgeRenderer
               isRentable={
                 (!!singlePriceInfo?.rent
-                  || !!seriesPriceInfo?.rent)
+                  || (!!seriesPriceInfo?.rent && bookDetail?.series?.property.is_serial))
                 && ['general', 'romance', 'bl'].includes(genre)
               }
               isWaitFree={bookDetail?.series?.property.is_wait_free}

--- a/src/utils/books.ts
+++ b/src/utils/books.ts
@@ -38,7 +38,7 @@ export function getThumbnailIdFromBookDetail(book: BookApi.Book | null) {
   if (!book) {
     return null;
   }
-  if (book.series) {
+  if (book.series && book.series.property.is_serial) {
     if (
       !book.series.property.is_completed && book.series.property.opened_last_volume_id.length !== 0
     ) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -88,8 +88,8 @@ export const getMaxDiscountPercentage = (book: BookApi.Book | null) => {
   }
   const singleBuyDiscountPercentage = book.price_info?.buy?.discount_percentage || 0;
   const singleRentDiscountPercentage = book.price_info?.rent?.discount_percentage || 0;
-  const seriesBuyDiscountPercentage = book.series?.price_info?.buy?.discount_percentage || 0;
-  const seriesRentDiscountPercentage = book.series?.price_info?.rent?.discount_percentage || 0;
+  const seriesBuyDiscountPercentage = book.series?.property.is_serial ? book.series?.price_info?.buy?.discount_percentage || 0 : 0;
+  const seriesRentDiscountPercentage = book.series?.property.is_serial ? book.series?.price_info?.rent?.discount_percentage || 0 : 0;
 
   const excludeMax = [
     singleBuyDiscountPercentage,


### PR DESCRIPTION
~~- [ ] 가격이 기존 페이지와 다른 문제~~
가격 정보는 새 브랜치 파서 다시 진행해야 할 듯 합니다.

- [x] last opened volume id 를 보여주지 않아도 되는(시리즈가 아닌) 도서 예외처리
- [x] SearchLandscapeBook 에서 원본 bId 입력하도록 수정
- [x] 대여배지 표시 오류 수정
- [x] 렌트 가격 정보 수정