### PR TITLE
책 정보 구성방식 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "emotion": "^10.0.23",
     "emotion-server": "^10.0.17",
     "emotion-theming": "^10.0.19",
+    "entities": "^2.0.2",
     "immer-reducer": "^0.7.9",
     "intersection-observer": "^0.7.0",
     "jwt-decode": "^2.2.0",

--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -1,6 +1,6 @@
-import { getEscapedNode } from 'src/utils/highlight';
 import { css } from '@emotion/core';
-import { computeSearchBookTitle } from 'src/utils/bookTitleGenerator';
+import isPropValid from '@emotion/is-prop-valid';
+import styled from '@emotion/styled';
 import {
   dodgerBlue50,
   orange40,
@@ -10,16 +10,18 @@ import {
   slateGray50,
   slateGray60,
 } from '@ridi/colors';
-import Link from 'next/link';
 import * as React from 'react';
+import Link from 'next/link';
+
+import { getEscapedNode } from 'src/utils/highlight';
+import { constructSearchDesc } from 'src/utils/books';
+import { computeSearchBookTitle } from 'src/utils/bookTitleGenerator';
 import { BreakPoint, greaterThanOrEqualTo, orBelow } from 'src/utils/mediaQuery';
 import * as SearchTypes from 'src/types/searchResults';
 import { AuthorsInfo } from 'src/types/searchResults';
 import * as BookApi from 'src/types/book';
 import { AuthorRole } from 'src/types/book';
-import styled from '@emotion/styled';
 import Star from 'src/svgs/Star.svg';
-import isPropValid from '@emotion/is-prop-valid';
 import ThumbnailWithBadge from 'src/components/Book/ThumbnailWithBadge';
 import { lineClamp } from 'src/styles';
 import { useBookSelector } from 'src/hooks/useBookDetailSelector';
@@ -342,13 +344,8 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
     parent_category_name: item.parent_category_name,
     parent_category_name2: item.parent_category_name2,
   };
-  // Fixme desc.intro === '책 정보가 없습니다' 일 경우 처리 확인
-  const clearDesc = (book?.clientBookFields?.desc?.intro ?? '')
-    .replace(/[\r\n]/g, ' ')
-    .replace(/&#10;/g, ' ')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/(<([^>]+)>)/gi, '');
+  const rawDesc = book?.clientBookFields?.desc;
+  const clearDesc = rawDesc ? constructSearchDesc(rawDesc) : '';
   // 대여 배지 표기 여부가 장르에 따라 바뀌기 때문에 장르를 모아둠
   const genres = book?.categories.map((category) => category.sub_genre) ?? ['general'];
   let translator: AuthorsInfo | undefined;

--- a/src/tests/utils/books.spec.ts
+++ b/src/tests/utils/books.spec.ts
@@ -21,9 +21,9 @@ describe('constructSearchDesc', () => {
       publisher_review: 'publisher',
     }, '<출판사 서평> publisher'],
     [{
-      intro: 'intro\r\nwith newline',
+      intro: 'intro\r\nwith newline and &lt;angular brackets&gt;',
       toc: 'toc\r\nwith <b>tags</b> &amp; entities',
-    }, 'intro with newline <목차> toc with tags & entities'],
+    }, 'intro with newline and <angular brackets> <목차> toc with tags & entities'],
   ])('should construct description correctly', (description, expected) => {
     expect(constructSearchDesc(description)).toBe(expected);
   });

--- a/src/tests/utils/books.spec.ts
+++ b/src/tests/utils/books.spec.ts
@@ -1,0 +1,30 @@
+import { constructSearchDesc } from 'src/utils/books';
+
+describe('constructSearchDesc', () => {
+  it.each([
+    [{
+    }, ''],
+    [{
+      intro: 'intro',
+      toc: 'toc',
+    }, 'intro <목차> toc'],
+    [{
+      intro: 'intro',
+      author: 'author',
+      toc: 'toc',
+    }, 'intro <저자 소개> author <목차> toc'],
+    [{
+      intro: 'intro',
+      publisher_review: 'publisher',
+    }, 'intro <출판사 서평> publisher'],
+    [{
+      publisher_review: 'publisher',
+    }, '<출판사 서평> publisher'],
+    [{
+      intro: 'intro\r\nwith newline',
+      toc: 'toc\r\nwith <b>tags</b> &amp; entities',
+    }, 'intro with newline <목차> toc with tags & entities'],
+  ])('should construct description correctly', (description, expected) => {
+    expect(constructSearchDesc(description)).toBe(expected);
+  });
+});

--- a/src/utils/books.ts
+++ b/src/utils/books.ts
@@ -4,9 +4,10 @@ import * as BookApi from 'src/types/book';
 
 function decodeDescField(options: { value?: string; prefix?: string }): string {
   const { value = '', prefix } = options;
-  const decoded = decodeHTML(value)
+  const stripped = value
     .replace(/\r?\n/g, ' ')
     .replace(/(<([^>]+)>)/gi, '');
+  const decoded = decodeHTML(stripped);
   if (prefix != null && decoded !== '') {
     return `<${prefix}> ${decoded}`;
   }

--- a/src/utils/books.ts
+++ b/src/utils/books.ts
@@ -1,4 +1,36 @@
+import { decodeHTML } from 'entities';
+
 import * as BookApi from 'src/types/book';
+
+function decodeDescField(options: { value?: string; prefix?: string }): string {
+  const { value = '', prefix } = options;
+  const decoded = decodeHTML(value)
+    .replace(/\r?\n/g, ' ')
+    .replace(/(<([^>]+)>)/gi, '');
+  if (prefix != null && decoded !== '') {
+    return `<${prefix}> ${decoded}`;
+  }
+  return decoded;
+}
+
+export function constructSearchDesc(description: BookApi.BookDesc): string {
+  const intro = decodeDescField({ value: description.intro });
+  const publisherReview = decodeDescField({
+    value: description.publisher_review,
+    prefix: '출판사 서평',
+  });
+  const author = decodeDescField({
+    value: description.author,
+    prefix: '저자 소개',
+  });
+  const toc = decodeDescField({
+    value: description.toc,
+    prefix: '목차',
+  });
+  return [intro, publisherReview, author, toc]
+    .filter((value) => value !== '')
+    .join(' ');
+}
 
 /* 미완결 된 Series 도서중 공개(opened) 된 마지막 회차의 표지 ID를 구함 */
 export function getThumbnailIdFromBookDetail(book: BookApi.Book | null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5385,10 +5385,10 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-entities@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
-  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
+entities@^2.0.0, entities@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.2.tgz#ac74db0bba8d33808bbf36809c3a5c3683531436"
+  integrity sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"


### PR DESCRIPTION
- 책 정보 - 출판사 서평 - 저자 소개 - 목차 순서대로 책 정보를 구성합니다.
- `entities`를 사용해 HTML entity decode를 수행합니다. 태그는 기존 방식대로 손으로 지웠습니다.
