### PR TITLE
가격 정보 표시 수정

### DIFF
--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -190,14 +190,23 @@ const SearchBookMetaWrapper = styled.div`
    width: 100%;
 `;
 
-function PriceLabel(props: { title: string; price: number; discount?: number }) {
-  const { title, price, discount = 0 } = props;
-  const realPrice = (price - Math.ceil(price * (discount / 100))).toLocaleString('ko-KR');
+function PriceLabel(props: {
+  title: string;
+  price: number;
+  discount?: number;
+  regularPrice: number;
+}) {
+  const {
+    title,
+    price,
+    discount = 0,
+    regularPrice,
+  } = props;
   return (
     <PriceItem>
       <PriceTitle>{title}</PriceTitle>
       <dd>
-        <Price>{price === 0 ? '무료' : `${realPrice}원`}</Price>
+        <Price>{price === 0 ? '무료' : `${price.toLocaleString('ko-KR')}원`}</Price>
         {' '}
         {discount > 0 && (
           <>
@@ -208,7 +217,7 @@ function PriceLabel(props: { title: string; price: number; discount?: number }) 
             </Discount>
             {' '}
             <OriginalPrice>
-              {price.toLocaleString('ko-KR')}
+              {regularPrice.toLocaleString('ko-KR')}
               원
             </OriginalPrice>
           </>
@@ -219,62 +228,83 @@ function PriceLabel(props: { title: string; price: number; discount?: number }) 
 }
 
 function PriceInfo(props: {
-  seriesPriceInfo: SearchTypes.SeriesPriceInfo[];
-  book: BookApi.ClientBook;
-  isTrial: boolean;
+  searchApiResult: SearchTypes.SearchBookDetail;
+  bookApiResult: BookApi.ClientBook;
+  genre: string;
 }) {
-  if (!props.book) {
+  const { searchApiResult, bookApiResult, genre } = props;
+  if (!props.bookApiResult) {
     return null;
   }
-  const { book, isTrial } = props;
+  const {
+    property: { is_trial },
+    price_info,
+  } = bookApiResult;
+  const { price, series_prices_info } = searchApiResult;
+
   const seriesPriceInfo: Record<string, SearchTypes.SeriesPriceInfo> = {};
-  props.seriesPriceInfo.forEach((info) => {
+  series_prices_info.forEach((info) => {
     seriesPriceInfo[info.type] = info;
   });
-  if (book.series?.property.is_serial && (seriesPriceInfo.rent || seriesPriceInfo.normal)) {
+  // 체험판 부터 거른다.
+  if (is_trial) {
+    return <PriceLabel title="구매" price={0} discount={0} regularPrice={0} />;
+  }
+  if (price_info && price !== 0) {
     return (
       <>
-        {seriesPriceInfo.rent && !book.property.is_trial && (
+        {price_info.rent && (
           <PriceLabel
             title="대여"
             price={
-              seriesPriceInfo.rent.min_price !== 0
-                ? seriesPriceInfo.rent.min_price
-                : seriesPriceInfo.rent.max_price
+              price_info.rent.price === 0 && seriesPriceInfo.rent
+                ? seriesPriceInfo.rent.min_nonzero_price
+                : price_info.rent.price
             }
+            discount={
+              price_info.rent.discount_percentage === 100
+                ? 0
+                : price_info.rent.discount_percentage
+            }
+            regularPrice={price_info.rent.regular_price}
+          />
+        )}
+        <PriceLabel
+          title="구매"
+          price={
+            seriesPriceInfo.normal && genre !== 'general'
+              ? Math.min(price, seriesPriceInfo.normal.min_nonzero_price)
+              : price
+          }
+          discount={price_info.buy ? price_info.buy.discount_percentage : 0}
+          regularPrice={price_info.buy?.regular_price ?? 0}
+        />
+      </>
+    );
+  }
+  if (seriesPriceInfo && price === 0) {
+    return (
+      <>
+        {seriesPriceInfo.rent && (
+          <PriceLabel
+            title="대여"
+            price={seriesPriceInfo.rent.min_nonzero_price}
+            discount={0}
+            regularPrice={price_info?.rent?.regular_price ?? 0}
           />
         )}
         {seriesPriceInfo.normal && (
           <PriceLabel
             title="구매"
-            price={isTrial ? 0 : seriesPriceInfo.normal.min_nonzero_price}
-          />
-        )}
-      </>
-    );
-  }
-
-  // 체험판
-  if (!book.price_info && book.property.is_trial) {
-    return <PriceLabel title="구매" price={0} discount={0} />;
-  }
-  if (book.price_info) {
-    const { buy = null, rent = null } = book.price_info;
-    return (
-      <>
-        {rent && (
-          <PriceLabel
-            title="대여"
-            // https://rididev.slack.com/archives/CE55MTQH2/p1589365195037000
-            price={rent.price === 0 ? rent.regular_price : rent.price}
-            discount={rent.discount_percentage}
-          />
-        )}
-        {buy && (
-          <PriceLabel
-            title="구매"
-            price={isTrial ? 0 : buy.regular_price}
-            discount={buy.discount_percentage}
+            price={
+              seriesPriceInfo.normal.min_price !== 0
+                ? Math.min(
+                  seriesPriceInfo.normal.min_nonzero_price,
+                  seriesPriceInfo.normal.min_price,
+                )
+                : seriesPriceInfo.normal.min_nonzero_price
+            }
+            regularPrice={price_info?.buy?.regular_price ?? 0}
           />
         )}
       </>
@@ -465,9 +495,9 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
           </BookDesc>
         </a>
         <PriceInfo
-          seriesPriceInfo={item.series_prices_info}
-          book={book}
-          isTrial={book.property.is_trial || false}
+          searchApiResult={item}
+          bookApiResult={book}
+          genre={genres[0] ?? ''}
         />
       </SearchBookMetaWrapper>
     </>

--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -251,7 +251,7 @@ function PriceInfo(props: {
     return <PriceLabel title="구매" price={0} discount={0} regularPrice={0} />;
   }
   // 진정한 무료 책
-  if (seriesPriceInfo === {} && price === 0 && price_info?.buy?.price === 0) {
+  if (!seriesPriceInfo.normal && price === 0 && price_info?.buy?.price === 0) {
     return <PriceLabel title="구매" price={0} discount={0} regularPrice={0} />;
   }
   if (price_info && price !== 0) {

--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -250,6 +250,10 @@ function PriceInfo(props: {
   if (is_trial) {
     return <PriceLabel title="구매" price={0} discount={0} regularPrice={0} />;
   }
+  // 진정한 무료 책
+  if (seriesPriceInfo === {} && price === 0 && price_info?.buy?.price === 0) {
+    return <PriceLabel title="구매" price={0} discount={0} regularPrice={0} />;
+  }
   if (price_info && price !== 0) {
     return (
       <>
@@ -310,6 +314,7 @@ function PriceInfo(props: {
       </>
     );
   }
+
   return null;
 }
 


### PR DESCRIPTION
가격 표시 부분을 다시 작성
 - 무료책, 체험판 도서 부터 걸러냄
 - 일반 장르를 제외한 도서가 series 가격 정보가 있다면 가장 싼 가격을 표시
 - 일반 장르이며 시리즈는 도서 가격(from search-api) 자체를 표시
 - book-api 의 정가 정보를 이용해서 정가도 넣어 줌
 - search-api 가격정보가 0원인데 가격이 표시되어야 하는 부분 분기

