### PR TITLE
작가 이름 표시 및 앵커 처리

### DIFF
--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -380,8 +380,13 @@ const SkeletonBar = styled.div<{width: string}>`
   margin-bottom: 8px;
 `;
 
-function RenderAuthors(props: { authors: AuthorsInfo[]}) {
-  const { authors } = props;
+function RenderAuthors(props: { authors: AuthorsInfo[]; fallback: string}) {
+  const { authors, fallback } = props;
+  if (authors.length === 0) {
+    return (
+      <a href={`/search?${fallback}`}>{fallback}</a>
+    );
+  }
   if (authors.length === 1) {
     return (
       <a href={`/author/${authors[0].author_id}`}>{authors[0].name}</a>
@@ -455,9 +460,7 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
         <SearchBookMetaList>
           <SearchBookMetaItem>
             <SearchBookMetaField type="author">
-              {
-                authors.length > 0 ? <RenderAuthors authors={authors} /> : <a href={`/search?q=${item.author}`}>{item.author}</a>
-              }
+              <RenderAuthors authors={authors} fallback={item.author} />
             </SearchBookMetaField>
           </SearchBookMetaItem>
           {translator && (

--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -380,7 +380,7 @@ const SkeletonBar = styled.div<{width: string}>`
   margin-bottom: 8px;
 `;
 
-function RenderAuthors(props: { authors: AuthorsInfo[]; fallback: string}) {
+function RenderAuthors(props: { authors: AuthorsInfo[]; fallback: string }) {
   const { authors, fallback } = props;
   if (authors.length === 0) {
     return (

--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -380,6 +380,23 @@ const SkeletonBar = styled.div<{width: string}>`
   margin-bottom: 8px;
 `;
 
+function RenderAuthors(props: { authors: AuthorsInfo[]}) {
+  const { authors } = props;
+  if (authors.length === 1) {
+    return (
+      <a href={`/author/${authors[0].author_id}`}>{authors[0].name}</a>
+    );
+  }
+  return (
+    <>
+      <a href={`/author/${authors[0].author_id}`}>{authors[0].name}</a>
+      {', '}
+      <a href={`/author/${authors[1].author_id}`}>{authors[1].name}</a>
+      {authors.length > 2 && ` 외 ${authors.length - 2}명`}
+    </>
+  );
+}
+
 export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
   const { item, title } = props;
   const book = useBookSelector(item.b_id);
@@ -410,9 +427,12 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
   // 대여 배지 표기 여부가 장르에 따라 바뀌기 때문에 장르를 모아둠
   const genres = book.categories.map((category) => category.sub_genre) ?? ['general'];
   let translator: AuthorsInfo | undefined;
+  const authors: AuthorsInfo[] = [];
   item.authors_info.forEach((author) => {
     if (author.role === AuthorRole.TRANSLATOR) {
       translator = author;
+    } else {
+      authors.push(author);
     }
   });
   return (
@@ -435,10 +455,9 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
         <SearchBookMetaList>
           <SearchBookMetaItem>
             <SearchBookMetaField type="author">
-              {/* Todo 저자 Anchor */}
-              {item.highlight.author
-                ? getEscapedNode(item.highlight.author)
-                : item.author}
+              {
+                authors.length > 0 ? <RenderAuthors authors={authors} /> : <a href={`/search?q=${item.author}`}>{item.author}</a>
+              }
             </SearchBookMetaField>
           </SearchBookMetaItem>
           {translator && (


### PR DESCRIPTION
하이라이팅 정보가 고유 작가의 이름을 여러 다른 별칭으로 보여주기 때문에 아직은 신뢰할 수 없어 authors_info 로 하이라이팅은 하지 않고 `저자1, 저자2, 그외 저자 표시`
ex) `표도르 미하일로비치 도스토예프스키`, `도스토예프스키`, `도스토옙스키`, `표도르 도스토예프스키`

https://app.asana.com/0/inbox/947013990233241/1165923352032319/1171978433718401
```
작가 이름은 일반적으로 CP가 입력하는 데이터고, 작가 DB는 내부에서 데이터 정제를 한 작가 정보라 작가 DB가 상대적으로 정확(?) 합니다.
모든 케이스에서 작가 DB가 우선순위가 높으니 참고 부탁드립니다!
```