### PR TITLE
도서 unit 올바르게 표시, 체험판을 제외한 총 권수 표시

### DIFF
--- a/src/components/Book/SearchLandscapeBook.tsx
+++ b/src/components/Book/SearchLandscapeBook.tsx
@@ -486,7 +486,7 @@ export function SearchLandscapeBook(props: SearchLandscapeBookProps) {
           {item.book_count > 1 && book.categories[0].is_series_category && (
             <SearchBookMetaItem>
               <SearchBookMetaField type="normal">
-                {`총 ${item.book_count}권`}
+                {`총 ${book.series?.price_info?.buy?.total_book_count || item.book_count}${book.series?.property.unit || '권'}`}
               </SearchBookMetaField>
               {item.series_prices_info.length > 0 && book.series?.property.is_serial_complete && (
                 <SeriesCompleted>완결</SeriesCompleted>


### PR DESCRIPTION
총 도서 권수는 book-api series total_book_count 가 정확함
(체험판을 제외한 권 수) 

도서 unit 올바르게 표시
