### PR TITLE
hotfix/transpileModules entities 포함(IE11 대응)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -133,7 +133,7 @@ module.exports = withPlugins([
     },
   }],
   [withTM, {
-    transpileModules: ['p-retry'],
+    transpileModules: ['p-retry', 'entities'],
   }],
   [withImages, {
     inlineImageLimit: 0,


### PR DESCRIPTION
IE11 에서 entities 모듈이 제대로 동작하지 않는 부분을 수정합니다.