### PR TITLE
InstantSearch 리팩토링 (1)

### DIFF
--- a/src/components/Search/InstantSearchHistory.tsx
+++ b/src/components/Search/InstantSearchHistory.tsx
@@ -115,7 +115,6 @@ interface InstantSearchHistoryProps {
   handleRemoveHistory: (e: React.MouseEvent<HTMLButtonElement>) => void;
   handleClearHistory: (e: React.MouseEvent<HTMLButtonElement>) => void;
   handleToggleSearchHistoryRecord: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  handleKeyDown: (e: React.KeyboardEvent<HTMLLIElement>) => void;
   searchHistory: string[];
   focusedPosition: number;
 }
@@ -128,7 +127,6 @@ const InstantSearchHistory: React.FC<InstantSearchHistoryProps> = (props) => {
     handleClickHistoryItem,
     handleToggleSearchHistoryRecord,
     searchHistory,
-    handleKeyDown,
     focusedPosition,
   } = props;
 
@@ -156,7 +154,6 @@ const InstantSearchHistory: React.FC<InstantSearchHistoryProps> = (props) => {
                 tabIndex={0}
                 data-value={history}
                 onClick={handleClickHistoryItem}
-                onKeyDown={handleKeyDown}
                 key={index}
               >
                 {/* Fixme href */}


### PR DESCRIPTION
리액트스러운 코드를 만들려면 다 갈아엎어야 할 것 같은 기분이 들어서 최소한으로 진행했습니다.

* callback ref는 여기저기 옮겨붙일 때마다 붙은 엘리먼트와 함께 호출됩니다.
* 눌린 키를 확인할 때는 `key`를 사용합니다(IE >=9). 그 외의 것들은 전부 deprecated되었습니다.
* `useEffect`를 잘 활용합시다. 리액트는 리액티브 프로그래밍을 장려하는 프레임워크입니다.
