### PR TITLE
book-api 에 runtypes 적용

### DIFF
--- a/src/components/Search/InstantSearchResult.tsx
+++ b/src/components/Search/InstantSearchResult.tsx
@@ -7,7 +7,6 @@ import { gray100, slateGray50 } from '@ridi/colors';
 import { ADULT_BADGE_URL } from 'src/constants/icons';
 import * as SearchTypes from 'src/types/searchResults';
 
-import { AuthorRole } from 'src/types/book';
 import AuthorInfo from './Authors/AuthorInfo';
 import { SearchResult } from './types';
 
@@ -169,7 +168,7 @@ interface InstantSearchResultProps {
 const AuthorLabel: React.FC<{ author: string; authors: SearchTypes.AuthorsInfo[] }> = (props) => {
   const viewedAuthors = props.authors
     && props.authors
-      .filter((author) => author.role !== AuthorRole.TRANSLATOR)
+      .filter((author) => author.role !== 'translator')
       .map((author) => author.name);
   if (!viewedAuthors || viewedAuthors.length === 0) {
     return <Author>{props.author}</Author>;

--- a/src/components/Search/SearchLandscapeBook/index.tsx
+++ b/src/components/Search/SearchLandscapeBook/index.tsx
@@ -17,7 +17,6 @@ import { computeSearchBookTitle } from 'src/utils/bookTitleGenerator';
 import { BreakPoint, greaterThanOrEqualTo, orBelow } from 'src/utils/mediaQuery';
 import * as SearchTypes from 'src/types/searchResults';
 import { AuthorsInfo } from 'src/types/searchResults';
-import { AuthorRole } from 'src/types/book';
 import Star from 'src/svgs/Star.svg';
 import ThumbnailWithBadge from 'src/components/Book/ThumbnailWithBadge';
 import { lineClamp } from 'src/styles';
@@ -239,7 +238,7 @@ export default function SearchLandscapeBook(props: SearchLandscapeBookProps) {
   let translator: AuthorsInfo | undefined;
   const authors: AuthorsInfo[] = [];
   item.authors_info.forEach((author) => {
-    if (author.role === AuthorRole.TRANSLATOR) {
+    if (author.role === 'translator') {
       translator = author;
     } else {
       authors.push(author);

--- a/src/services/books/request.ts
+++ b/src/services/books/request.ts
@@ -1,16 +1,23 @@
+import * as R from 'runtypes';
+
 import * as BookApi from 'src/types/book';
 import axios from 'src/utils/axios';
 import sentry from 'src/utils/sentry';
 
-export const requestBooks = async (b_ids: string[]) => {
+export const requestBooks = async (b_ids: string[]): Promise<BookApi.Book[]> => {
   try {
-    const { data } = await axios.get<BookApi.Book[]>('/books', {
+    const { data } = await axios.get('/books', {
       baseURL: process.env.NEXT_STATIC_BOOK_API,
       params: {
         b_ids: b_ids.join(),
       },
     });
-    return data;
+    try {
+      return R.Array(BookApi.RBookData).check(data);
+    } catch (error) {
+      sentry.captureException(error);
+      return data as BookApi.Book[];
+    }
   } catch (error) {
     sentry.captureException(error);
     return [];

--- a/src/tests/__mocks__/mockModules.tsx
+++ b/src/tests/__mocks__/mockModules.tsx
@@ -86,7 +86,9 @@ export const initModules = () => {
       Tracker: class Tracker {
         constructor() {}
         initialize() {}
+        sendPageView() {}
         sendEvent() {}
+        set() {}
       },
     };
   });

--- a/src/tests/components/Book/PriceInfo.spec.tsx
+++ b/src/tests/components/Book/PriceInfo.spec.tsx
@@ -3,7 +3,6 @@ import { getByText, render } from '@testing-library/react';
 import PriceInfo from 'src/components/Search/SearchLandscapeBook/PriceInfo';
 import * as SearchTypes from 'src/types/searchResults';
 import * as BookApi from 'src/types/book';
-import { AuthorRole } from 'src/types/book';
 import '@testing-library/jest-dom/extend-expect';
 
 // rental 1,900
@@ -68,7 +67,7 @@ const searchApiPriceExistFixture = {
         },
       },
     },
-    authors: [{ name: '\uacbd\uc694', role: AuthorRole.AUTHOR, id: 1 }],
+    authors: [{ name: '\uacbd\uc694', role: 'author', id: 1 }],
     file: {
       size: 679,
       format: 'epub',
@@ -259,8 +258,8 @@ const trialBookFixture = {
       },
     },
     authors: [
-      { name: '\ub9c8\uc11c\ud718', id: 1741, role: AuthorRole.AUTHOR },
-      { name: '\uae40\ucc2c\uc5f0', id: 1733, role: AuthorRole.TRANSLATOR },
+      { name: '\ub9c8\uc11c\ud718', id: 1741, role: 'author' },
+      { name: '\uae40\ucc2c\uc5f0', id: 1733, role: 'translator' },
     ],
     file: {
       size: 502,
@@ -367,14 +366,14 @@ const trialBookFixture = {
     category: 117,
     authors_info: [
       {
-        role: AuthorRole.TRANSLATOR,
+        role: 'translator',
         name: '김찬연',
         author_id: 1733,
         native_name: '',
         order: 0,
       },
       {
-        role: AuthorRole.AUTHOR,
+        role: 'author',
         name: '마서휘',
         author_id: 1741,
         native_name: '馬書輝',
@@ -418,7 +417,7 @@ const freeBookFixture: Fixture = {
       paper: { price: 0 },
       buy: { regular_price: 0, price: 0, discount_percentage: 0 },
     },
-    authors: [{ name: '\ub8e8\uc774 \ubca1', id: 26030, role: AuthorRole.AUTHOR }],
+    authors: [{ name: '\ub8e8\uc774 \ubca1', id: 26030, role: 'author' }],
     file: {
       size: 784,
       format: 'epub',
@@ -500,7 +499,7 @@ const freeBookFixture: Fixture = {
     category: 1400,
     authors_info: [
       {
-        role: AuthorRole.AUTHOR,
+        role: 'author',
         name: '루이 벡',
         author_id: 26030,
         alias_name: 'Louis Becke',
@@ -573,7 +572,7 @@ const priceZeroFixture: Fixture = {
         },
       },
     },
-    authors: [{ name: '\uc2f1\uc211', id: 72276, role: AuthorRole.AUTHOR }],
+    authors: [{ name: '\uc2f1\uc211', id: 72276, role: 'author' }],
     file: {
       size: 1877,
       format: 'epub',
@@ -667,7 +666,7 @@ const priceZeroFixture: Fixture = {
     category: 1753,
     authors_info: [
       {
-        role: AuthorRole.AUTHOR,
+        role: 'author',
         name: '싱숑',
         author_id: 72276,
         native_name: '',

--- a/src/tests/components/MultipleLineBook/MultipleLineBookComponent.spec.tsx
+++ b/src/tests/components/MultipleLineBook/MultipleLineBookComponent.spec.tsx
@@ -14,7 +14,6 @@ import { MultipleLineBooks } from 'src/components/MultipleLineBooks/MultipleLine
 import { defaultTheme } from 'src/styles';
 import makeStore from 'src/store/config';
 import { ViewportIntersectionProvider } from 'src/hooks/useViewportIntersection';
-import { AuthorRole } from 'src/types/book';
 
 afterEach(cleanup);
 const store = makeStore(
@@ -79,7 +78,7 @@ const store = makeStore(
               },
             },
           },
-          authors: [{ name: '조선비즈', role: AuthorRole.AUTHOR, id: 1 }],
+          authors: [{ name: '조선비즈', role: 'author', id: 1 }],
           file: {
             size: 232,
             format: 'epub',

--- a/src/tests/components/RecommendedBook/RecommendedBook.spec.tsx
+++ b/src/tests/components/RecommendedBook/RecommendedBook.spec.tsx
@@ -17,7 +17,6 @@ import { defaultTheme } from 'src/styles';
 import makeStore from 'src/store/config';
 import { ViewportIntersectionProvider } from 'src/hooks/useViewportIntersection';
 import { HotRelease, TodayRecommendation } from '../../../types/sections';
-import { AuthorRole } from 'src/types/book';
 
 afterEach(cleanup);
 const store = makeStore(
@@ -39,7 +38,7 @@ const store = makeStore(
           title: {main: '도서 표지'},
           categories: [{genre: 'comic'}],
           property: {},
-          authors: [{id: 1, role: AuthorRole.AUTHOR, name: '작가'}],
+          authors: [{id: 1, role: 'author', name: '작가'}],
           clientBookFields: {
             isAvailableSelect: true,
             isAlreadyCheckedAtSelect: true,

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -1,220 +1,140 @@
-import { SearchBookDetail } from 'src/types/searchResults';
+import * as R from 'runtypes';
 
-export enum AuthorRole {
-  AUTHOR = 'author',
-  COMIC_AUTHOR = 'comic_author',
-  STORY_WRITER = 'story_writer',
-  TRANSLATOR = 'translator',
-  ILLUSTRATOR = 'illustrator',
-  ORIGINAL_AUTHOR = 'original_author',
-  AUTHOR_PHOTO = 'author_photo',
-  PLANNER = 'planner',
-  BIBLIOGRAPHICAL_INTRODUCTION = 'bibliographical_introduction',
-  COMPILER = 'compiler',
-  COMMENTATOR = 'commentator',
-  EDITOR = 'editor',
-  SUPERVISE = 'supervise',
-  PERFORMER = 'performer',
-  ORIGINAL_ILLUSTRATOR = 'original_illustrator',
-}
+const RCategory = R.Record({
+  id: R.Number,
+  name: R.String,
+  genre: R.String,
+  sub_genre: R.String,
+  is_series_category: R.Boolean,
+});
 
-export interface Title {
-  main: string;
-  prefix?: string;
-  sub?: string;
-}
-export interface Category {
-  id: number;
-  is_series_category: boolean;
-  name: string;
-  genre: string | '';
-  sub_genre: string;
-}
+const RPriceItem = R.Record({
+  regular_price: R.Number,
+  price: R.Number,
+  discount_percentage: R.Number,
+});
 
-export interface File {
-  character_count: number;
-  format: string;
-  is_comic: boolean;
-  is_comic_hd: boolean;
-  is_drm_free: boolean;
-  is_manga: boolean;
-  is_webtoon: boolean;
-  size: number;
-  page_count?: number;
-}
+const RRentPriceItem = RPriceItem.And(R.Record({
+  rent_days: R.Number,
+}));
 
-export interface BuyInfo {
-  discount_percentage: number;
-  price: number;
-  regular_price: number;
-}
+const RSeriesPriceItem = RPriceItem.And(R.Record({
+  total_book_count: R.Number,
+  free_book_count: R.Number,
+}));
 
-export interface SeriesBuyInfo {
-  free_book_count: number;
-  price: number;
-  regular_price: number;
-  total_book_count: number;
-  discount_percentage: number;
-}
+const RSeriesRentPriceItem = R.Record({
+  regular_price: R.Number,
+  rent_price: R.Number,
+  discount_percentage: R.Number,
+  rent_days: R.Number,
+  total_book_count: R.Number,
+  free_book_count: R.Number,
+});
 
-export interface SeriesRentBuyInfo {
-  total_book_count: number;
-  free_book_count: number;
-  regular_price: number;
-  rent_price: number;
-  rent_days: number;
-  discount_percentage: number;
-}
+const RPriceInfo = R.Partial({
+  buy: RPriceItem,
+  rent: RRentPriceItem,
+});
 
-export interface SeriesPriceInfo {
-  buy?: SeriesBuyInfo;
-  rent?: SeriesRentBuyInfo;
-}
+const RSeriesPriceInfo = R.Partial({
+  buy: RSeriesPriceItem,
+  rent: RSeriesRentPriceItem,
+});
 
-export interface PaperBuyInfo {
-  price: number;
-}
+const RSeries = R.Record({
+  id: R.String,
+  volume: R.Number,
+  property: R.Record({
+    last_volume_id: R.String,
+    opened_last_volume_id: R.String,
+    title: R.String.Or(R.Null),
+    unit: R.String.Or(R.Null),
+    opened_book_count: R.Number,
+    total_book_count: R.Number,
+    is_serial: R.Boolean,
+    is_completed: R.Boolean,
+    is_comic_hd: R.Boolean,
+    is_serial_complete: R.Boolean,
+    is_wait_free: R.Boolean,
+  }),
+}).And(
+  R.Partial({
+    price_info: RSeriesPriceInfo,
+  }),
+);
 
-export interface RentInfo {
-  regular_price: number;
-  price: number;
-  rent_days: number;
-  discount_percentage: number;
-}
+const RAuthor = R.Record({
+  name: R.String,
+  role: R.String,
+}).And(
+  R.Partial({
+    id: R.Number,
+  }),
+);
+export type Author = R.Static<typeof RAuthor>;
 
-export interface PointBackInfo {
-  pointback_amount: number;
-  point_duration: number;
-}
-
-interface PriceInfoCashBack {
-  cashback_period_start: string;
-  cashback_period_end: string;
-}
-
-interface PriceInfoPointBack {
-  pointback_amount?: number;
-  point_duration?: number;
-}
-
-export interface PriceInfo {
-  buy?: BuyInfo;
-  paper?: PaperBuyInfo;
-  rent?: RentInfo;
-  pointBackInfo?: PointBackInfo;
-  flatrate?: number;
-  cashback?: PriceInfoCashBack;
-  pointback?: PriceInfoPointBack;
-}
-
-export interface Property {
-  is_adult_only: boolean;
-  is_magazine: boolean;
-  is_new_book: boolean;
-  is_novel: boolean;
-  is_open: boolean;
-  is_somedeal: boolean;
-  is_trial: boolean;
-  preview_rate: number;
-  review_display_id?: string;
-  kpc_id?: string;
-  kd_stage?: number;
-  preview_max_characters?: number;
-  preview_max_pages?: number;
-}
-
-export interface LinkedSeriesBookInfo {
-  [b_id: string]: { b_id: string; is_opened: boolean };
-}
-
-export interface DeviceSupport {
-  android: boolean;
-  ios: boolean;
-  mac: boolean;
-  paper: boolean;
-  web_viewer: boolean;
-  windows: boolean;
-}
-
-export interface SeriesProperty {
-  is_comic_hd: boolean;
-  is_completed: boolean;
-  is_serial: boolean;
-  is_serial_complete: boolean;
-  is_wait_free: boolean;
-  opened_book_count: number;
-  opened_last_volume_id: string;
-  prev_books?: [] | LinkedSeriesBookInfo;
-  next_books?: [] | LinkedSeriesBookInfo;
-  last_volume_id: string;
-  title?: string;
-  total_book_count: number;
-  unit: string | null;
-}
-
-export interface Publish {
-  ebook_publish?: string;
-  ridibooks_publish?: string;
-  ridibooks_register?: string;
-  paper_book_publish?: Date | string;
-}
-
-export interface Publisher {
-  cp_name: string;
-  id: number;
-  name: string;
-}
-
-export interface Series {
-  id: string;
-  price_info: SeriesPriceInfo;
-  property: SeriesProperty;
-  volume: number;
-}
-
-export interface ThumbnailInfo {
-  large: string;
-  small: string;
-  xxlarge: string;
-}
-
-export interface SetBook {
-  member_books_count: number;
-}
+export const RBookData = R.Record({
+  id: R.String,
+  title: R.Record({
+    main: R.String,
+  }).And(R.Partial({
+    prefix: R.String,
+  })),
+  authors: R.Array(RAuthor),
+  categories: R.Array(RCategory).withConstraint((arr) => arr.length > 0),
+  price_info: RPriceInfo,
+  file: R.Record({
+    size: R.Number,
+    format: R.Union(R.String, R.Null),
+    is_drm_free: R.Boolean,
+    is_comic: R.Boolean,
+    is_webtoon: R.Boolean,
+    is_manga: R.Boolean,
+    is_comic_hd: R.Boolean,
+  }).And(
+    R.Partial({
+      character_count: R.Number,
+      page_count: R.Number,
+    }),
+  ),
+  property: R.Record({
+    is_novel: R.Boolean,
+    is_magazine: R.Boolean,
+    is_adult_only: R.Boolean,
+    is_new_book: R.Boolean,
+    is_open: R.Boolean,
+    is_somedeal: R.Boolean,
+    is_trial: R.Boolean,
+    preview_rate: R.Number,
+  }).And(
+    R.Partial({
+      review_display_id: R.String,
+    }),
+  ),
+  publisher: R.Record({
+    name: R.String,
+    cp_name: R.String,
+  }).And(
+    R.Partial({
+      id: R.Number,
+    }),
+  ),
+}).And(
+  R.Partial({
+    series: RSeries,
+    is_deleted: R.Boolean,
+    setbook: R.Record({
+      member_books_count: R.Number,
+    }),
+  }),
+);
+export type Book = R.Static<typeof RBookData>;
 
 export interface ClientBookFields {
   isAvailableSelect: boolean;
   isAlreadyCheckedAtSelect: boolean;
   desc?: BookDesc;
-}
-
-export interface Book {
-  id: string;
-  authors: Author[];
-  categories: Category[];
-  title: Title;
-  file: File;
-  last_modified: string;
-  price_info?: PriceInfo;
-  property: Property;
-  publish: Publish;
-  publisher?: Publisher;
-  series?: Series;
-  support: DeviceSupport;
-  thumbnail: ThumbnailInfo;
-  setbook?: SetBook;
-
-  //
-  is_deleted?: boolean;
-
-  // client field
-  thumbnailId?: string; // 시리즈 여부, 완결 여부 판단해서 최종적으로 보여 줄 thumbnail Id
-}
-
-export interface Author {
-  name: string;
-  id: number;
-  role: AuthorRole;
 }
 
 export interface BookDescResponse {

--- a/src/types/searchResults.ts
+++ b/src/types/searchResults.ts
@@ -1,7 +1,6 @@
 import * as R from 'runtypes';
 
 import Sentry from 'src/utils/sentry';
-import { AuthorRole } from 'src/types/book';
 
 const RAuthor = R.Record({
   popular_book_title: R.String,
@@ -55,7 +54,7 @@ const RSeriesPriceInfo = R.Record({
 export type SeriesPriceInfo = R.Static<typeof RSeriesPriceInfo>;
 
 const RAuthorsInfo = R.Record({
-  role: R.Unknown as R.Runtype<AuthorRole>,
+  role: R.String,
   name: R.String,
   author_id: R.Number,
   order: R.Number,

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -73,6 +73,9 @@ if (process.env.IS_SERVER || !window.isPartials) {
 
 const Sentry = {
   captureException(error: AxiosError | Error, ctx: ConnectedInitializeProps | null = null) {
+    if (!process.env.IS_PRODUCTION) {
+      console.error('Captured exception:', error);
+    }
     let eventId;
 
     withScope((scope) => {


### PR DESCRIPTION
장르 홈에 필요 하지 않은 데이터를 거르는 작업(book-api)을 하기위해 일단 타이핑 사전 작업을 했습니다.

@tirr-c 님이 [library-books](https://github.com/ridi/library-books) 에 먼저 작업한 코드가 있어서 같이 추가했습니다.  
