### PR TITLE
AIRecommendationBook 타입 사용처 제거

### DIFF
--- a/src/components/BookSections/SelectionBook/SelectionBookCarousel.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookCarousel.tsx
@@ -65,7 +65,7 @@ const SelectionBookCarousel: React.FC<SelectionBookListProps> = (props) => {
             order={index}
             genre={genre}
             slug={slug}
-            book={items[index] as any /* TODO do type circus */}
+            book={items[index]}
             type={type}
           />
         )}

--- a/src/components/BookSections/SelectionBook/SelectionBookItem.tsx
+++ b/src/components/BookSections/SelectionBook/SelectionBookItem.tsx
@@ -2,31 +2,17 @@ import React, { useCallback } from 'react';
 
 import BookMeta from 'src/components/BookMeta';
 import { sendClickEvent, useEventTracker } from 'src/hooks/useEventTracker';
-import {
-  AIRecommendationBook,
-  DisplayType,
-  BookItem,
-} from 'src/types/sections';
+import { DisplayType, BookItem } from 'src/types/sections';
 import PortraitBook from 'src/components/Book/PortraitBook';
 
-interface CommonProps {
+interface Props {
+  type: DisplayType;
   order?: number;
   slug: string;
   genre: string;
   className?: string;
-}
-
-interface MdBookProps {
-  type: Exclude<DisplayType, 'AiRecommendation'>;
   book: BookItem;
 }
-
-interface AIRecommendationBookProps {
-  type: 'AiRecommendation';
-  book: AIRecommendationBook;
-}
-
-type Props = CommonProps & (MdBookProps | AIRecommendationBookProps);
 
 const SelectionBookItem: React.FC<Props> = (props) => {
   const {

--- a/src/components/BookSections/SelectionBook/types.ts
+++ b/src/components/BookSections/SelectionBook/types.ts
@@ -1,18 +1,10 @@
-import { DisplayType, AIRecommendationBook, BookItem } from 'src/types/sections';
+import { DisplayType, BookItem } from 'src/types/sections';
 
 export interface SelectionBookCommonProps {
+  type: DisplayType;
   genre: string;
   slug: string;
-}
-
-export interface SelectionBookMdProps {
-  type: Exclude<DisplayType, 'AiRecommendation'>;
   items: BookItem[]; // Fixme Md 타입 말고 comics UserPreferredSection 타입이 API 결과로 오는데 이 부분 확인해야 함
 }
 
-export interface SelectionBookAiRecommendationProps {
-  type: 'AiRecommendation';
-  items: AIRecommendationBook[];
-}
-
-export type SelectionBookListProps = SelectionBookCommonProps & (SelectionBookMdProps | SelectionBookAiRecommendationProps);
+export type SelectionBookListProps = SelectionBookCommonProps;


### PR DESCRIPTION
이제 `rcmd_id`가 없으니 기존 타입을 그대로 쓸 수 있습니다.
