### PR TITLE
hotfix/추천 영역 센트리 불필요한 알림 발송 수정

### DIFF
--- a/src/components/Section/AIRecommendationSection.tsx
+++ b/src/components/Section/AIRecommendationSection.tsx
@@ -55,7 +55,10 @@ const AiRecommendationSection: React.FC<AiRecommendationSectionProps> = (props) 
         }
       } catch (error) {
         setIsRequestError(true);
-        sentry.captureException(error);
+        // 추천할 도서가 없으면 404 반환함 에러가 아님
+        if (error?.response?.status !== 404) {
+          sentry.captureException(error);
+        }
       }
     };
 


### PR DESCRIPTION
`인증이 실패했을 때는 401로 응답합니다. 인증은 성공했는데, 해당 u_idx에 대해 추천 결과가 없다면 404로 응답하고 있습니다.`
관련 타래
https://rididev.slack.com/archives/C0129Q139L7/p1590719576001800?thread_ts=1590717302.000700&cid=C0129Q139L7
