### PR TITLE
알림 확인 때 OAuthRequestType 이 Strict 인 부분 Check 로 수정

### DIFF
--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -12,7 +12,7 @@ import HomeLink from 'src/components/GNB/HomeLink';
 import DoublePointIcon from 'src/svgs/DoublePoint.svg';
 import CashIcon from 'src/svgs/Cash.svg';
 import pRetry from 'p-retry';
-import axios, { CancelToken, OAuthRequestType, wrapCatchCancel } from 'src/utils/axios';
+import axios, { CancelToken, wrapCatchCancel } from 'src/utils/axios';
 import sentry from 'src/utils/sentry';
 import { RIDIBOOKS_LOGO_URL, RIDISELECT_LOGO_URL } from 'src/constants/icons';
 import useAccount from 'src/hooks/useAccount';
@@ -182,7 +182,6 @@ const GNBButtons: React.FC<GNBButtonsProps> = (props) => {
         const result = await pRetry(
           () => wrapCatchCancel(axios.get)(cartUrl, {
             withCredentials: true,
-            custom: { authorizationRequestType: OAuthRequestType.CHECK },
             cancelToken: source.token,
           }),
           {

--- a/src/components/Section/AIRecommendationSection.tsx
+++ b/src/components/Section/AIRecommendationSection.tsx
@@ -2,7 +2,7 @@ import { AIRecommendationBook, SectionExtra } from 'src/types/sections';
 import SelectionBook from 'src/components/BookSections/SelectionBook';
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import axios, { CancelToken, OAuthRequestType } from 'src/utils/axios';
+import axios, { CancelToken } from 'src/utils/axios';
 import sentry from 'src/utils/sentry';
 import { booksActions } from 'src/services/books';
 import { useRouter } from 'next/router';
@@ -40,7 +40,6 @@ const AiRecommendationSection: React.FC<AiRecommendationSectionProps> = (props) 
         const result = await axios.get(requestUrl, {
           baseURL: process.env.NEXT_STATIC_AI_RECOMMENDATION_API,
           withCredentials: true,
-          custom: { authorizationRequestType: OAuthRequestType.CHECK },
           timeout: 8000,
           cancelToken: source.token,
         });

--- a/src/components/Section/UserPreferredSection.tsx
+++ b/src/components/Section/UserPreferredSection.tsx
@@ -3,7 +3,7 @@ import SelectionBook from 'src/components/BookSections/SelectionBook';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from 'src/store/config';
-import axios, { OAuthRequestType } from 'src/utils/axios';
+import axios from 'src/utils/axios';
 import sentry from 'src/utils/sentry';
 import { keyToArray } from 'src/utils/common';
 import { booksActions } from 'src/services/books';
@@ -34,7 +34,6 @@ const UserPreferredSection: React.FC<UserPreferredSectionProps> = (props) => {
         const requestUrl = `${process.env.NEXT_STATIC_STORE_API}/sections/home-${genre}-user-preferred-bestseller/`;
         const result = await axios.get(requestUrl, {
           withCredentials: true,
-          custom: { authorizationRequestType: OAuthRequestType.CHECK },
           timeout: 8000,
         });
         if (result.status === 200) {

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -2,7 +2,7 @@ import { configureScope } from '@sentry/browser';
 import libAxios, { CancelTokenSource, AxiosError } from 'axios';
 import React from 'react';
 
-import axios, { CancelToken, OAuthRequestType } from 'src/utils/axios';
+import axios, { CancelToken } from 'src/utils/axios';
 import { CancelledError, runWithExponentialBackoff } from 'src/utils/backoff';
 import * as tracker from 'src/utils/event-tracker';
 import Sentry from 'src/utils/sentry';
@@ -15,9 +15,6 @@ export async function checkLoggedIn(cancel: CancelTokenSource) {
     const { data } = await axios.get<{ result: LoggedUser}>('/accounts/me', {
       baseURL: process.env.NEXT_STATIC_ACCOUNT_API,
       withCredentials: true,
-      custom: {
-        authorizationRequestType: OAuthRequestType.CHECK,
-      },
       cancelToken: cancel.token,
     });
     return data.result;

--- a/src/hooks/useCartCount.tsx
+++ b/src/hooks/useCartCount.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import pRetry from 'p-retry';
-import axios, { CancelToken, OAuthRequestType } from 'src/utils/axios';
+import axios, { CancelToken } from 'src/utils/axios';
 import sentry from 'src/utils/sentry';
 import { LoggedUser } from 'src/types/account';
 
@@ -16,7 +16,6 @@ export const useCartCount = (loggedUserInfo: LoggedUser | null) => {
             baseURL: process.env.NEXT_STATIC_LEGACY_STORE_API_HOST,
             withCredentials: true,
             cancelToken: source.token,
-            custom: { authorizationRequestType: OAuthRequestType.CHECK },
           }),
           { retries: 2 },
         );

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -40,7 +40,7 @@ async function requestNotificationAuth() {
   const { data } = await axios.get<NotificationAuthResponse>(
     `${process.env.NEXT_STATIC_STORE_API}/users/me/notification-token/`,
     {
-      custom: { authorizationRequestType: OAuthRequestType.STRICT },
+      custom: { authorizationRequestType: OAuthRequestType.CHECK },
       withCredentials: true,
     },
   );
@@ -53,7 +53,7 @@ async function requestNotification(limit: number, token: string) {
     `${process.env.NEXT_STATIC_STORE_API}/notification`,
     {
       params: { limit },
-      custom: { authorizationRequestType: OAuthRequestType.STRICT },
+      custom: { authorizationRequestType: OAuthRequestType.CHECK },
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import Cookies from 'universal-cookie';
 
 import { Notification } from 'src/types/notification';
-import axios, { OAuthRequestType } from 'src/utils/axios';
+import axios from 'src/utils/axios';
 import { runWithExponentialBackoff } from 'src/utils/backoff';
 import sentry from 'src/utils/sentry';
 
@@ -40,7 +40,6 @@ async function requestNotificationAuth() {
   const { data } = await axios.get<NotificationAuthResponse>(
     `${process.env.NEXT_STATIC_STORE_API}/users/me/notification-token/`,
     {
-      custom: { authorizationRequestType: OAuthRequestType.CHECK },
       withCredentials: true,
     },
   );
@@ -53,7 +52,6 @@ async function requestNotification(limit: number, token: string) {
     `${process.env.NEXT_STATIC_STORE_API}/notification`,
     {
       params: { limit },
-      custom: { authorizationRequestType: OAuthRequestType.CHECK },
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/src/types/axios/index.d.ts
+++ b/src/types/axios/index.d.ts
@@ -1,8 +1,0 @@
-import 'axios';
-
-declare module 'axios' {
-  import { CustomRequestConfig } from 'src/utils/axios';
-  export interface AxiosRequestConfig {
-    custom?: CustomRequestConfig;
-  }
-}

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -2,16 +2,6 @@ import axios, { AxiosInstance } from 'axios';
 import { AbortError } from 'p-retry';
 import { tokenInterceptor } from 'src/utils/axiosInterceptors';
 
-export enum OAuthRequestType {
-  NORMAL = 'NORMAL', // 실패하더라도 특별한 행동을 하지 않는다
-  CHECK = 'CHECK', // rt 갱신 시도, at 확인 후 실패하더라도 실패한 결과를 반환
-  STRICT = 'STRICT', // rt 갱신, at 확인 후 로그인되지 않았다면 로그인 페이지로 이동
-}
-
-export interface CustomRequestConfig {
-  authorizationRequestType: OAuthRequestType;
-}
-
 export const { CancelToken } = axios;
 
 // eslint-disable-next-line no-process-env

--- a/src/utils/axiosInterceptors.ts
+++ b/src/utils/axiosInterceptors.ts
@@ -1,20 +1,9 @@
 import axios, { AxiosError } from 'axios';
-import { OAuthRequestType } from 'src/utils/axios';
-
-export const redirectOAuthLoginPage = () => {
-  const loginURL = new URL('/ridi/authorize/', process.env.NEXT_STATIC_ACCOUNT_API);
-  loginURL.searchParams.append('client_id', process.env.NEXT_STATIC_RIDI_OAUTH2_CLIENT_ID || '');
-  loginURL.searchParams.append('response_type', 'code');
-  loginURL.searchParams.append('redirect_uri', location.href);
-
-  location.href = loginURL.toString();
-};
 
 export const authorizeTokenFallback = async (rejectedError: AxiosError) => {
   await axios.get('/ridi/authorize/', {
     withCredentials: true,
     baseURL: process.env.NEXT_STATIC_ACCOUNT_API,
-    custom: rejectedError.config.custom,
     params: {
       client_id: process.env.NEXT_STATIC_RIDI_OAUTH2_CLIENT_ID,
       response_type: 'code',
@@ -31,24 +20,14 @@ export const refreshTokenFallback = async (rejectedError: AxiosError) => {
     await axios.post('/ridi/token', null, {
       baseURL: process.env.NEXT_STATIC_ACCOUNT_API,
       withCredentials: true,
-      custom: rejectedError.config.custom,
     });
   } catch (error) {
     const { response } = error;
-    const { custom } = rejectedError.config;
     if (!response) {
       return Promise.reject(error);
     }
-    if (!custom) {
-      return Promise.reject(rejectedError);
-    }
-    if (custom.authorizationRequestType === OAuthRequestType.STRICT) {
-      redirectOAuthLoginPage();
-    }
-    if (custom.authorizationRequestType === OAuthRequestType.CHECK) {
-      // Access-Token 확인
-      return authorizeTokenFallback(rejectedError);
-    }
+    // Access-Token 확인
+    return authorizeTokenFallback(rejectedError);
   }
 
   // 원본 요청
@@ -56,16 +35,8 @@ export const refreshTokenFallback = async (rejectedError: AxiosError) => {
 };
 
 export const tokenInterceptor = (onRejected: AxiosError) => {
-  const { response, config } = onRejected;
+  const { response } = onRejected;
   if (!response) {
-    return Promise.reject(onRejected);
-  }
-  if (!config.custom) {
-    return Promise.reject(onRejected);
-  }
-
-  const { authorizationRequestType } = config.custom;
-  if (authorizationRequestType === OAuthRequestType.NORMAL) {
     return Promise.reject(onRejected);
   }
 


### PR DESCRIPTION
현재 `/notification` 페이지는 백엔드 프록싱을 거치고 해당 부분에서 로그인 페이지 이동 처리를 하기 때문에  `STRICT` 체크를 할 필요가 없습니다.

in-app 은 올라간 후 확인이 필요합니다.
