### PR TITLE
올바른 토큰을 가지고 있을 경우 로컬 상태에 setToken

### DIFF
--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -124,8 +124,7 @@ export function NotificationProvider(props: { children?: React.ReactNode }) {
           sentry.captureException(err);
         },
       );
-    }
-    if (!token && !isExpired) {
+    } else {
       setToken(newToken);
     }
   }, []);

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -125,6 +125,9 @@ export function NotificationProvider(props: { children?: React.ReactNode }) {
         },
       );
     }
+    if (!token && !isExpired) {
+      setToken(newToken);
+    }
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
Context 상태에 token 이 null 일 경우가 존재해 알림을 획득하지 못하는 경우가 있어
useEffect 에서 `setToken` 을 해주도록 변경했습니다.