### PR TITLE
redux 스토어에서 사용되지 않는 isFetching 제거

### DIFF
--- a/src/services/books/saga.ts
+++ b/src/services/books/saga.ts
@@ -62,10 +62,8 @@ function* watchCheckSelectBookIds(action: Actions<typeof BooksReducer>) {
       const arrays = splitArrayToChunk(excludedIds, DEFAULT_BOOKS_ID_CHUNK_SIZE);
 
       yield all(arrays.map((array) => isAvailableAtSelect(array)));
-      yield put({ type: booksActions.setFetching.type, payload: false });
     }
   } catch (error) {
-    yield put({ type: booksActions.setFetching.type, payload: false });
     sentry.captureException(error);
   }
 }
@@ -80,10 +78,8 @@ function* watchInsertBookIds(action: Actions<typeof BooksReducer>) {
       const arrays = splitArrayToChunk(excludedIds, DEFAULT_BOOKS_ID_CHUNK_SIZE);
 
       yield all(arrays.map((array) => fetchBooks(array, action.payload.withDesc)));
-      yield put({ type: booksActions.setFetching.type, payload: false });
     }
   } catch (error) {
-    yield put({ type: booksActions.setFetching.type, payload: false });
     sentry.captureException(error);
   }
 }

--- a/src/services/category/reducer.ts
+++ b/src/services/category/reducer.ts
@@ -5,12 +5,10 @@ import * as CategoryApi from 'src/types/category';
 
 export interface CategoryState {
   items: { [key: number]: CategoryApi.Category | null };
-  isFetching: boolean;
 }
 
 export const categoryInitialState: CategoryState = {
   items: {},
-  isFetching: false,
 };
 
 export class CategoryReducer extends ImmerReducer<CategoryState> {
@@ -22,7 +20,6 @@ export class CategoryReducer extends ImmerReducer<CategoryState> {
         categories[item] = null;
       }
     });
-    this.draftState.isFetching = true;
     this.draftState.items = { ...this.draftState.items, ...categories };
   }
 
@@ -32,10 +29,6 @@ export class CategoryReducer extends ImmerReducer<CategoryState> {
       categories[category.id] = category;
     });
     this.draftState.items = { ...this.draftState.items, ...categories };
-  }
-
-  public setFetching(payload: boolean) {
-    this.draftState.isFetching = payload;
   }
 }
 
@@ -50,7 +43,6 @@ export function categoryReducer(
   if (action.type === HYDRATE) {
     return {
       items: { ...state.items, ...action.payload.categories.items },
-      isFetching: state.isFetching,
     };
   }
   return innerCategoryReducer(state, action as any);

--- a/src/services/category/saga.ts
+++ b/src/services/category/saga.ts
@@ -35,10 +35,8 @@ function* watchInsertCategoryIds(action: Actions<typeof CategoryReducer>) {
       const arrays = splitArrayToChunk(excludedIds, DEFAULT_CHUNK_SIZE);
 
       yield all(arrays.map((array) => fetchCategories(array)));
-      yield put({ type: categoryActions.setFetching.type, payload: false });
     }
   } catch (error) {
-    yield put({ type: categoryActions.setFetching.type, payload: false });
     sentry.captureException(error);
   }
 }

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -2,11 +2,9 @@ import { RootState } from './config';
 
 export const initialState: RootState = {
   books: {
-    isFetching: false,
     items: {},
   },
   categories: {
-    isFetching: false,
     items: {},
   },
 };

--- a/src/tests/components/BookSelections/RankingBookList.spec.tsx
+++ b/src/tests/components/BookSelections/RankingBookList.spec.tsx
@@ -26,7 +26,6 @@ const store = makeStore(
           authors: [{name: 'Ridi', id: '1', role: 'author'}]
         },
       },
-      isFetching: false,
     },
   },
 );

--- a/src/tests/components/BookSelections/SelectionBook.spec.tsx
+++ b/src/tests/components/BookSelections/SelectionBook.spec.tsx
@@ -29,7 +29,6 @@ const store = makeStore(
           categories: [{ genre: 'general' }],
         },
       },
-      isFetching: false,
     },
   },
 );

--- a/src/tests/components/EventBanner/EventBanner.spec.tsx
+++ b/src/tests/components/EventBanner/EventBanner.spec.tsx
@@ -15,7 +15,6 @@ const store = makeStore(
       itmes: {
         '12345': null,
       },
-      isFetching: false,
     },
   },
 );

--- a/src/tests/components/MultipleLineBook/MultipleLineBookComponent.spec.tsx
+++ b/src/tests/components/MultipleLineBook/MultipleLineBookComponent.spec.tsx
@@ -20,7 +20,6 @@ const store = makeStore(
   {
     categories: {
       items: {},
-      isFetching: false,
     },
     books: {
       items: {
@@ -64,8 +63,6 @@ const store = makeStore(
         },
         '2414000749': null,
       },
-
-      isFetching: false,
     },
   },
 );

--- a/src/tests/components/QuickMenu/QuickMenuList.spec.tsx
+++ b/src/tests/components/QuickMenu/QuickMenuList.spec.tsx
@@ -15,7 +15,6 @@ const store = makeStore(
       itmes: {
         '12345': null,
       },
-      isFetching: false,
     },
   },
 );

--- a/src/tests/components/RecommendedBook/RecommendedBook.spec.tsx
+++ b/src/tests/components/RecommendedBook/RecommendedBook.spec.tsx
@@ -43,7 +43,6 @@ const store = makeStore(
           },
         },
       },
-      isFetching: false,
     },
   },
 );


### PR DESCRIPTION
대입은 되고 있으나 실제 사용되지는 않고 있던 `isFetching`을 제거합니다.

fetching 상태가 필요하다면 항목을 가져와서 null인지 체크하면 될 것 같습니다.
