### PR TITLE
히스토리 아이템 패딩 조정, outline 삭제, 삭제 버튼 크기 고정

### DIFF
--- a/src/components/Search/InstantSearchHistory.tsx
+++ b/src/components/Search/InstantSearchHistory.tsx
@@ -31,6 +31,10 @@ const RecentHistoryLabel = styled.p`
 
 const RemoveHistoryButton = styled.button`
   margin-left: 16px;
+  height: 42px;
+  width: 42px;
+  outline: none;
+  flex: none;
 `;
 
 const closeIcon = (theme: RIDITheme) => css`
@@ -55,7 +59,7 @@ const HistoryList = styled.ul`
 const SearchHistoryItem = styled.li`
   cursor: pointer;
   box-sizing: border-box;
-  padding: 12px 16px;
+  padding-left: 16px;
   font-size: 14px;
   line-height: 1;
   display: flex;
@@ -73,6 +77,7 @@ const SearchHistoryItem = styled.li`
     `,
   )};
   a {
+    padding: 14px 0;
     span {
       color: #303538;
       font-size: 15px;
@@ -107,6 +112,7 @@ const HistoryOptionPanel = styled.div`
 
 const HistoryOptionButton = styled.button`
   font-size: 14px;
+  outline: none;
 `;
 
 interface InstantSearchHistoryProps {


### PR DESCRIPTION
https://app.asana.com/0/1179224001436508/1180740684993119

## 좌측 - After  우측 - Before

![image](https://user-images.githubusercontent.com/45959991/84878501-e1682980-b0c4-11ea-92d0-db0378b08f64.png)
