### PR TITLE
setUnreadCount(0) after requestFetchNotifications

### DIFF
--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -172,6 +172,7 @@ export function NotificationProvider(props: { children?: React.ReactNode }) {
       setUnreadCount(data.unreadCount);
       setItems(data.notifications);
       await requestNotificationRead(token);
+      setUnreadCount(0);
     },
     [token],
   );


### PR DESCRIPTION
https://rididev.slack.com/archives/CHSBJC7U1/p1592879197254700

알림페이지 접근 시 GNB 알림 탭 뱃지가 바로 사라지도록 수정합니다.