### PR TITLE
인스턴트 검색 팝업 표시되지 않을 때 그림자 생기는 문제 수정

### DIFF
--- a/src/components/Search/InstantSearch/index.tsx
+++ b/src/components/Search/InstantSearch/index.tsx
@@ -507,9 +507,11 @@ export default function InstantSearch() {
             )}
           </SearchBoxShape>
         </SearchBoxWrapper>
-        <PopupWrapper focused={isFocused}>
-          {popup}
-        </PopupWrapper>
+        {popup && (
+          <PopupWrapper focused={isFocused}>
+            {popup}
+          </PopupWrapper>
+        )}
       </FocusTrap>
     </WrapperForm>
   );


### PR DESCRIPTION
보여줄 팝업이 없으면 래퍼도 그리지 않도록 했습니다.
