### PR TITLE
요청이 ALB를 통해 들어온 경우 쿼리스트링 디코드

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ module.exports.server = server;
 
 // binary mode
 // https://github.com/dougmoscrop/serverless-http/blob/master/docs/ADVANCED.md#binary-mode
-module.exports.handler = serverless(server, {
+const handler = serverless(server, {
   binary: [
     'application/javascript',
     'application/json',
@@ -66,3 +66,16 @@ module.exports.handler = serverless(server, {
     'text/xml',
   ],
 });
+
+module.exports.handler = (event, context) => {
+  // decode query params for ALB
+  // Node.js 12.x에서 Object.fromEntries 사용 가능함
+  if (event.requestContext && event.requestContext.elb) {
+    const params = Object.fromEntries(
+      Object.entries(event.queryStringParameters)
+        .map(([key, value]) => [decodeURIComponent(key), decodeURIComponent(value)])
+    );
+    event.queryStringParameters = params;
+  }
+  return handler(event, context);
+};


### PR DESCRIPTION
요청이 람다로 전송될 때 API Gateway는 쿼리스트링을 디코드하지만 ALB는 그러지 않습니다.
