### PR TITLE
인앱 검색 페이지 배경 색상을 흰색으로 고정

### DIFF
--- a/src/pages/inapp/search.tsx
+++ b/src/pages/inapp/search.tsx
@@ -1,4 +1,10 @@
 import React from 'react';
+import { Global, css } from '@emotion/core';
 import SearchPage from 'src/pages/search';
 
-export default () => <SearchPage forceAdultExclude />;
+export default () => (
+  <>
+    <Global styles={css`html {background: white; }`} />
+    <SearchPage forceAdultExclude />
+  </>
+);


### PR DESCRIPTION
인앱 검색페이지에서 dark 테마를 지원하기 전까지 배경 색상을 흰색으로 고정합니다..