### PR TITLE
Fix: 책에서 title prefix 사용하는 부분 제거

### DIFF
--- a/src/utils/bookTitleGenerator.ts
+++ b/src/utils/bookTitleGenerator.ts
@@ -14,11 +14,6 @@ export function computeBookTitle(book: BookApi.Book | null): string {
     if (book.series) {
       return book.series.property.title || book.title.main;
     }
-    if (book.title) {
-      if (book.title.prefix) {
-        return `${book.title.prefix} ${book.title.main}`;
-      }
-    }
     return book.title.main;
   } catch (error) {
     sentry.captureException(error);


### PR DESCRIPTION
- 책에서 title prefix 사용하는 부분 제거
- 검색결과에서만 노출하기로 하여 전부 제거하게 되었습니다.