### PR TITLE
MainTab Indicator 만화 웹툰 비활성화 문제 해결

### DIFF
--- a/src/components/Tabs/MainTab.tsx
+++ b/src/components/Tabs/MainTab.tsx
@@ -325,7 +325,7 @@ export default function MainTab(props: MainTabProps) {
           normalIcon={<Home css={iconStyle} />}
           label={labels.mainTab.home}
           path="/"
-          pathRegexp={/^\/(romance|romance-serial|fantasy|fantasy-serial|bl-novel|bl-webnovel|bl-comics|bl-webtoon|comics)?\/?$/}
+          pathRegexp={/^\/(romance|romance-serial|fantasy|fantasy-serial|bl-novel|bl-webnovel|bl-comics|bl-webtoon|comics|webtoon)?\/?$/}
         />
         <TabItem
           activeIcon={<NotificationSolid css={iconStyle} />}


### PR DESCRIPTION
[ASANA TASK](https://app.asana.com/0/1200028901501882/1200091177766144/f)

Issue
만화 - 웹툰 카테고리 진입 시 MainTab의 홈 Indicator 비활성화 되던 문제

Solve
TabItem의 pathRegexp에 만화-웹툰의 경로가 누락되어있던 부분 추가
이전까지 만화-웹툰의 경우는 계속 비활성화 되어 있었을 것으로 추정됨