### PR TITLE
Feature/ga4

### DIFF
--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -7,6 +7,7 @@ import { CancelledError, runWithExponentialBackoff } from 'src/utils/backoff';
 import * as tracker from 'src/utils/event-tracker';
 import Sentry from 'src/utils/sentry';
 import { LoggedUser } from 'src/types/account';
+import * as ga4Tracker from 'src/utils/event-tracker-ga4';
 
 export const AccountContext = React.createContext<LoggedUser | null>(null);
 
@@ -44,6 +45,7 @@ export function AccountProvider(props: { children?: React.ReactNode }) {
           scope.setUser(data);
         });
         tracker.setUserId(data?.id ?? null);
+        ga4Tracker.setUserIdx(data?.idx?.toString() ?? null);
         setAccount(data);
       },
       (err) => {

--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -138,11 +138,7 @@ export const Home: NextPage<HomeProps> = (props) => {
   }, [genre, loggedUser, setPageView]);
 
   useEffect(() => {
-    ga4.initialize();
-  }, [genre]);
-
-  useEffect(() => {
-    ga4.setUserIdx(loggedUser ? loggedUser.idx.toString() : null);
+    ga4.initialize(loggedUser ? loggedUser.idx.toString() : null);
   }, [loggedUser]);
 
 

--- a/src/utils/event-tracker-ga4.ts
+++ b/src/utils/event-tracker-ga4.ts
@@ -19,7 +19,6 @@ function loadTagManager(id: string) {
   return (function (w, d, s) {
     if (w) {
       gtag('js', new Date());
-      gtagConfig();
 
       const f = d.getElementsByTagName(s)[0]; const
         j: any = d.createElement(s);
@@ -31,13 +30,29 @@ function loadTagManager(id: string) {
   }(window, document, 'script'));
 }
 
-let isInitialized = false;
-export function initialize() {
-  if (!isInitialized && loadTagManager(GA4_KEY)) {
-    isInitialized = true;
+function cleanPrevUser(userIdx: string | null) {
+  if (window && Array.isArray(window.dataLayer)) {
+    window.dataLayer = window.dataLayer.filter((i: any) => {
+      if (typeof i[2] === 'object') {
+        const prevUserIdx = i[2]?.user_id;
+        if (prevUserIdx !== userIdx) {
+          return false;
+        }
+      }
+      return true;
+    });
   }
 }
 
 export function setUserIdx(userIdx: string | null) {
+  cleanPrevUser(userIdx);
   gtagConfig({ user_id: userIdx });
+}
+
+let initialized = false;
+export function initialize(userIdx: string | null) {
+  if (!initialized && loadTagManager(GA4_KEY)) {
+    setUserIdx(userIdx);
+    initialized = true;
+  }
 }

--- a/src/utils/event-tracker-ga4.ts
+++ b/src/utils/event-tracker-ga4.ts
@@ -33,7 +33,7 @@ function loadTagManager(id: string) {
 function cleanPrevUser(userIdx: string | null) {
   if (window && Array.isArray(window.dataLayer)) {
     window.dataLayer = window.dataLayer.filter((i: any) => {
-      if (typeof i[2] === 'object') {
+      if (i[1] === GA4_KEY && typeof i[2] === 'object') {
         const prevUserIdx = i[2]?.user_id;
         if (prevUserIdx !== userIdx) {
           return false;


### PR DESCRIPTION
GA4 page_view 이벤트 생성을 위해 gtag.config을 호출하는데,
이 때 Custom(user-scoped)인 이벤트 파라메터 user_id가 변경되는 경우(즉, 로그인),
서로 다른 user_id(이 경우 실제 uidx 또는 null 두가지)에 대해 page_view 이벤트가 중복 발생합니다.

이를 방지하기 위해 setUserId 호출시 기존 user_id가 포함된 gtag.config 입력값을 window.dataLayer에서 제거합니다.