### PR TITLE
Feature/ga4

### DIFF
--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -45,7 +45,13 @@ export function AccountProvider(props: { children?: React.ReactNode }) {
           scope.setUser(data);
         });
         tracker.setUserId(data?.id ?? null);
-        ga4Tracker.setUserIdx(data?.idx?.toString() ?? null);
+
+        const userIdx = data?.idx;
+        if (userIdx) {
+          ga4Tracker.setUserIdx(userIdx.toString());
+        } else {
+          ga4Tracker.initWithoutUser();
+        }
         setAccount(data);
       },
       (err) => {
@@ -55,6 +61,7 @@ export function AccountProvider(props: { children?: React.ReactNode }) {
           }
           return;
         }
+        ga4Tracker.initWithoutUser();
         Sentry.captureException(err);
       },
     );

--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -138,8 +138,8 @@ export const Home: NextPage<HomeProps> = (props) => {
   }, [genre, loggedUser, setPageView]);
 
   useEffect(() => {
-    ga4.initialize(loggedUser ? loggedUser.idx.toString() : null);
-  }, [loggedUser]);
+    ga4.initialize();
+  }, []);
 
 
   useEffect(() => {

--- a/src/utils/event-tracker-ga4.ts
+++ b/src/utils/event-tracker-ga4.ts
@@ -33,7 +33,7 @@ function loadTagManager(id: string) {
 function cleanPrevUser() {
   if (window && Array.isArray(window.dataLayer)) {
     window.dataLayer = window.dataLayer.filter((i: any) => {
-      if (i[1] === GA4_KEY && i[2]?.user_id) {
+      if (i[0] === 'config' && i[1] === GA4_KEY) {
         return false;
       }
       return true;

--- a/src/utils/event-tracker-ga4.ts
+++ b/src/utils/event-tracker-ga4.ts
@@ -49,10 +49,13 @@ export function setUserIdx(userIdx: string | null) {
   gtagConfig({ user_id: userIdx });
 }
 
+export function initWithoutUser() {
+  gtagConfig();
+}
+
 let initialized = false;
-export function initialize(userIdx: string | null) {
+export function initialize() {
   if (!initialized && loadTagManager(GA4_KEY)) {
-    setUserIdx(userIdx);
     initialized = true;
   }
 }

--- a/src/utils/event-tracker-ga4.ts
+++ b/src/utils/event-tracker-ga4.ts
@@ -30,14 +30,11 @@ function loadTagManager(id: string) {
   }(window, document, 'script'));
 }
 
-function cleanPrevUser(userIdx: string | null) {
+function cleanPrevUser() {
   if (window && Array.isArray(window.dataLayer)) {
     window.dataLayer = window.dataLayer.filter((i: any) => {
-      if (i[1] === GA4_KEY && typeof i[2] === 'object') {
-        const prevUserIdx = i[2]?.user_id;
-        if (prevUserIdx !== userIdx) {
-          return false;
-        }
+      if (i[1] === GA4_KEY && i[2]?.user_id) {
+        return false;
       }
       return true;
     });
@@ -45,11 +42,12 @@ function cleanPrevUser(userIdx: string | null) {
 }
 
 export function setUserIdx(userIdx: string | null) {
-  cleanPrevUser(userIdx);
+  cleanPrevUser();
   gtagConfig({ user_id: userIdx });
 }
 
 export function initWithoutUser() {
+  cleanPrevUser();
   gtagConfig();
 }
 


### PR DESCRIPTION
- React Lifecycle 의존 없이 Login 로직의 결과에 따라서만 user_id를 설정하도록 변경
- 방어적으로 기존에 존재할 지 모르는 "동일" GA4 ID의 "다른" user_id인 경우 모두 필터를 통해 제거

감사합니다!