### PR TITLE
GA4 view_item_list 장르홈 섹션에 대해 적용

### DIFF
--- a/src/components/BookSections/RankingBook/RankingBookList.tsx
+++ b/src/components/BookSections/RankingBook/RankingBookList.tsx
@@ -3,6 +3,8 @@ import BookMeta from 'src/components/BookMeta';
 import ScrollContainer from 'src/components/ScrollContainer';
 import { CLOCK_ICON_URL } from 'src/constants/icons';
 import { BookItem, Section, StarRating } from 'src/types/sections';
+import { useViewportIntersectionOnce } from 'src/hooks/useViewportIntersection';
+import { sendViewItemList } from 'src/utils/event-tracker-ga4';
 
 import { createTimeLabel } from 'src/utils/dateTime';
 import * as tracker from 'src/utils/event-tracker';
@@ -138,8 +140,14 @@ const RankingBookList: React.FunctionComponent<RankingBookListProps> = (props) =
     genre, type, showTimer, extra, title, showSomeDeal, slug, items: books,
   } = props;
 
+  const ref = useViewportIntersectionOnce<HTMLUListElement>(() => {
+    sendViewItemList(books, {
+      item_list_id: slug,
+    });
+  });
+
   return (
-    <Styled.SectionWrapper>
+    <Styled.SectionWrapper ref={ref}>
       {title && (
         <SectionTitle>
           {showTimer && <Timer />}

--- a/src/components/BookSections/SelectionBook/index.tsx
+++ b/src/components/BookSections/SelectionBook/index.tsx
@@ -7,6 +7,8 @@ import useIsTablet from 'src/hooks/useIsTablet';
 import { RootState } from 'src/store/config';
 import { SectionExtra } from 'src/types/sections';
 import { orBelow } from 'src/utils/mediaQuery';
+import { useViewportIntersectionOnce } from 'src/hooks/useViewportIntersection';
+import { sendViewItemList } from 'src/utils/event-tracker-ga4';
 
 import SelectionBookCarousel from './SelectionBookCarousel';
 import SelectionBookList from './SelectionBookList';
@@ -52,8 +54,13 @@ const SelectionBook: React.FunctionComponent<SelectionBookProps> = (props) => {
     sectionHref = `/selection/${selectionId}`;
   }
 
+  const ref = useViewportIntersectionOnce<HTMLUListElement>(() => {
+    sendViewItemList(items, {
+      item_list_id: slug,
+    });
+  });
   return (
-    <SectionWrapper>
+    <SectionWrapper ref={ref}>
       <SectionTitle>
         <SectionTitleLink title={`${isWebtoon ? '[웹툰] ' : ''}${title}`} href={sectionHref} />
       </SectionTitle>

--- a/src/components/MultipleLineBooks/MultipleLineBooks.tsx
+++ b/src/components/MultipleLineBooks/MultipleLineBooks.tsx
@@ -8,6 +8,8 @@ import BookMeta from 'src/components/BookMeta';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useBookSelector } from 'src/hooks/useBookDetailSelector';
 import * as tracker from 'src/utils/event-tracker';
+import { useViewportIntersectionOnce } from 'src/hooks/useViewportIntersection';
+import { sendViewItemList } from 'src/utils/event-tracker-ga4';
 import styled from '@emotion/styled';
 import ThumbnailWithBadge from '../Book/ThumbnailWithBadge';
 
@@ -249,8 +251,13 @@ export const MultipleLineBooks: React.FunctionComponent<MultipleLineBooks> = (pr
   const {
     title, items, genre, slug,
   } = props;
+  const ref = useViewportIntersectionOnce<HTMLUListElement>(() => {
+    sendViewItemList(items, {
+      item_list_id: slug,
+    });
+  });
   return (
-    <Section>
+    <Section ref={ref}>
       <Title aria-label={title}>{title}</Title>
       <ItemList genre={genre} slug={slug} books={items} />
     </Section>

--- a/src/components/RecommendedBook/index.tsx
+++ b/src/components/RecommendedBook/index.tsx
@@ -5,6 +5,8 @@ import useIsTablet from 'src/hooks/useIsTablet';
 import { BreakPoint } from 'src/utils/mediaQuery';
 
 import recommendedBookBackground from 'src/assets/image/recommended_book_background@desktop.png';
+import { useViewportIntersectionOnce } from 'src/hooks/useViewportIntersection';
+import { sendViewItemList } from 'src/utils/event-tracker-ga4';
 
 import RecommendedBookList from './RecommendedBookList';
 import RecommendedBookCarousel from './RecommendedBookCarousel';
@@ -57,10 +59,18 @@ export default function RecommendedBook(props: RecommendedBookProps) {
   const {
     theme,
     title,
+    items,
+    slug,
   } = props;
   const isTablet = useIsTablet();
+
+  const ref = useViewportIntersectionOnce<HTMLUListElement>(() => {
+    sendViewItemList(items, {
+      item_list_id: slug,
+    });
+  });
   return (
-    <RecommendedBookWrapper bg={theme}>
+    <RecommendedBookWrapper bg={theme} ref={ref}>
       <SectionTitle>{title}</SectionTitle>
       <div>
         {isTablet ? (

--- a/src/utils/event-tracker-ga4.ts
+++ b/src/utils/event-tracker-ga4.ts
@@ -15,6 +15,10 @@ function gtagConfig(...args: any[]) {
   gtag('config', GA4_KEY, ...args);
 }
 
+function gtagEvent(eventName: string, params: any) {
+  gtag('event', eventName, params);
+}
+
 function loadTagManager(id: string) {
   return (function (w, d, s) {
     if (w) {
@@ -43,4 +47,42 @@ export function initialize() {
   if (!initialized && loadTagManager(GA4_KEY)) {
     initialized = true;
   }
+}
+
+
+interface Item {
+  item_id: string;
+  item_name: string;
+  price?: string;
+  item_brand?: string;
+  item_category?: string;
+  item_category2?: string;
+  item_category3?: string;
+  item_category4?: string;
+  item_variant?: string;
+  item_list_name?: string;
+  item_list_id?: string;
+  index?: number;
+  quantity?: string;
+}
+function parseItem(bookLike: Record<string, unknown>): Item {
+  return {
+    item_id: bookLike.b_id as string,
+    item_name: bookLike.title as string,
+  };
+}
+
+interface SendViewItemListOptions {
+  item_list_id?: string;
+  item_list_name?: string;
+}
+export function sendViewItemList(books: Record<string, unknown>[], options: SendViewItemListOptions) {
+  const { item_list_id } = options || {};
+  const items = (books || []).map(parseItem).map((item, index) => ({
+    ...item,
+    item_list_id,
+    index,
+  }));
+
+  gtagEvent('view_item_list', { items });
 }


### PR DESCRIPTION
GA4에 view_item_list 이벤트를 전송하며, 이 때 items의 각 아이템마다 item_list_id에 section_id를 입력합니다.

관련 이슈
https://app.asana.com/0/1193106288044291/1200326235584594/f