### PR TITLE
마케팅 트래커 Hotjar 연동

### DIFF
--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -7,6 +7,7 @@ import { GenreTab } from 'src/components/Tabs';
 import titleGenerator, { genreKeys } from 'src/utils/titleGenerator';
 import { useDispatch } from 'react-redux';
 import { useRouter } from 'next/router';
+import { UAParser } from 'ua-parser-js';
 
 import { checkPage, Section } from 'src/types/sections';
 import HomeSectionRenderer from 'src/components/Section/HomeSectionRenderer';
@@ -33,6 +34,7 @@ export interface HomeProps {
   lazyLoadBIds?: string[];
   genre: string;
   ga4debug?: string;
+  nonce?: string;
 }
 
 const GENREHONE_CODE_PREFIX = 'open_genre_home';
@@ -83,6 +85,27 @@ const usePrevious = <T extends {}>(value: T) => {
   return ref.current;
 };
 
+const renderHotjarScript = (nonce?: string) => (
+  <script
+    async
+    nonce={nonce}
+
+    id="hotjar-init"
+    data-hjid={2334254}
+    dangerouslySetInnerHTML={{
+      __html: `(function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        hjid=document.getElementById('hotjar-init') && document.getElementById('hotjar-init').getAttribute('data-hjid');
+        h._hjSettings={hjid:hjid,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');`,
+    }}
+  />
+);
+
 export const Home: NextPage<HomeProps> = (props) => {
   const loggedUser = useAccount();
   const dispatch = useDispatch();
@@ -91,6 +114,9 @@ export const Home: NextPage<HomeProps> = (props) => {
   const { lazyLoadBIds, genre = 'general' } = props;
   const previousGenre = usePrevious(genre);
   const [branches, setBranches] = useState(props.branches || []);
+
+  const ua = new UAParser().getUA();
+  const isHotjarRenderable = !(window as any).ReactNativeWebView && ua.length && !ua.includes('ridibooks');
 
   useEffect(() => {
     const cookies = new Cookies();
@@ -175,6 +201,7 @@ export const Home: NextPage<HomeProps> = (props) => {
     <>
       <Head>
         <title>{`${titleGenerator(genre)} - 리디북스`}</title>
+        {isHotjarRenderable && renderHotjarScript(props.nonce)}
       </Head>
       <GenreTab currentGenre={genre} />
       {branches && branches.map((section, index) => (

--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -116,7 +116,12 @@ export const Home: NextPage<HomeProps> = (props) => {
   const [branches, setBranches] = useState(props.branches || []);
 
   const ua = new UAParser().getUA();
-  const isHotjarRenderable = !(window as any).ReactNativeWebView && ua.length && !ua.toLowerCase().includes('ridibooks');
+  const isHotjarRenderable = (
+    typeof window !== 'undefined'
+      && !(window as any).ReactNativeWebView
+      && ua.length
+      && !ua.toLowerCase().includes('ridibooks')
+  );
 
   useEffect(() => {
     const cookies = new Cookies();

--- a/src/pages/[genre]/index.tsx
+++ b/src/pages/[genre]/index.tsx
@@ -116,7 +116,7 @@ export const Home: NextPage<HomeProps> = (props) => {
   const [branches, setBranches] = useState(props.branches || []);
 
   const ua = new UAParser().getUA();
-  const isHotjarRenderable = !(window as any).ReactNativeWebView && ua.length && !ua.includes('ridibooks');
+  const isHotjarRenderable = !(window as any).ReactNativeWebView && ua.length && !ua.toLowerCase().includes('ridibooks');
 
   useEffect(() => {
     const cookies = new Cookies();


### PR DESCRIPTION
RidiApp에서 접근시 이를
1. user agent에 ridibooks/의 유무
2. RidiApp이 사용하는 WebViewer 라이브러리에서 window 객체에 생성하는 전역 변수 window.ReactNativeWebView

위 두 가지 경우를 고려하여 감지하고, 이에 해당되지 않을 때 Hotjar 마케팅 도구를 호출합니다.

해당 로직은 PHP에 별도로 적용하는데, 그 이유는 books-frontend로의 2차 호출시 user agent 전달이 제대로 되지 않아
[장르 홈]에 해당하는 Hotjar 호출만 books-frontend 코드 내에서 명시적으로 하고, 그 외에는 PHP에서 호출하기 때문입니다.

관련 커밋: https://github.com/ridi/books-backend/pull/672