### PR TITLE
hotjar.io를 CSP의 예외 항목으로 추가

### DIFF
--- a/src/components/Meta/CSP.tsx
+++ b/src/components/Meta/CSP.tsx
@@ -28,6 +28,7 @@ const whiteList = [
   'https://appboy-images.com',
   'https://unpkg.com',
   'https://*.hotjar.com',
+  'https://*.hotjar.io',
   'wss://*.hotjar.com',
 ];
 


### PR DESCRIPTION
CSP로 인해
https://vc.hotjar.io/sessions/2334254?s=0.25&r=0.03533273352392574 
과 같은 요청이 실패함에 따라 예외항목에 추가합니다.